### PR TITLE
feat(task-004): multiple choice play, E2E isolation, admin list filter

### DIFF
--- a/.cursor/rules/quiz-data-and-api.mdc
+++ b/.cursor/rules/quiz-data-and-api.mdc
@@ -8,6 +8,7 @@ alwaysApply: false
 
 ## Prisma
 
+- `datasource` dùng `env("DATABASE_URL")`: dev mặc định `file:./dev.db`, E2E `file:./e2e.db` (xem `package.json`, README). **Không** `migrate reset` trừ khi user yêu cầu; migration tránh `DELETE`/`DROP` hàng loạt dữ liệu user — chi tiết rule **`quiz-delivery-and-docs.mdc`** (mục dữ liệu local).
 - Đổi `schema.prisma` → **luôn** `migrate` (hoặc flow tương đương) + `generate`; cập nhật đồng thời chỗ đọc/ghi (API, server helpers, form).
 - `Quiz.type` là **chuỗi có tập hợp cố định**; trong TS dùng union / const enum thống nhất với `src/types` (tránh magic string rải rác).
 
@@ -15,7 +16,7 @@ alwaysApply: false
 
 - **POST/PUT** (và server actions nếu có) phải **branch theo `type`**:
   - `crossword_*`: bắt buộc field đúng spec (basic: `verticalWord` + đúng `N` câu theo từ khóa đã chuẩn hóa; **`letterIndex` do server gán**, client không tin).
-  - `multiple_choice`: đúng **15** câu, mỗi câu **4** option, **một** đáp án đúng; `order` hoặc `difficulty` phản ánh thứ tự khó tăng dần.
+  - `multiple_choice`: **≥1** câu trong ngân hàng, mỗi câu **4** option, **một** đáp án đúng (index 0–3), `difficulty` + `order`; **`playLength`** nguyên dương và ≤ số câu (`normalizeMultipleChoiceQuestions`). Public: `GET/POST /api/play/[shareLink]/multiple-choice-session` — GET không trả index đúng.
 - Không tin tưởng body từ client; từ chối rõ (400 + message) khi sai cấu trúc.
 
 ## Public play vs admin

--- a/.cursor/rules/quiz-delivery-and-docs.mdc
+++ b/.cursor/rules/quiz-delivery-and-docs.mdc
@@ -38,7 +38,22 @@ alwaysApply: true
 
 8. Khi thay đổi hành vi có thể hồi quy: ưu tiên **thêm hoặc sửa test** cùng code (khi đã có framework test).
 
-9. **E2E Playwright + tài liệu theo task** (task mới **và** fix bug có rủi ro hồi quy): làm theo rule **`quiz-e2e-and-test-docs.mdc`** — file `e2e/task-NNN-*.spec.ts`, cập nhật **`e2e-test-report.md`** (hoặc `fix-bug.md`) trong `tasks/task-NNN-*/`, hai lớp mô tả (nghiệp vụ + chuỗi thao tác UI).
+9. **E2E Playwright + tài liệu theo task** (task mới **và** fix bug có rủi ro hồi quy): làm theo rule **`quiz-e2e-and-test-docs.mdc`** — file `e2e/task-NNN-*.spec.ts`, cập nhật **`e2e-test-report.md`** trong `tasks/task-NNN-*/`; mỗi **sửa bug** còn bắt buộc **`fix-bug.md`** (mục **§10** dưới đây), hai lớp mô tả (nghiệp vụ + chuỗi thao tác UI).
+
+10. **Sửa bug — bắt buộc `fix-bug.md`:** mỗi lần **sửa bug** (hành vi sai so với spec, regression, hoặc chỉnh UX/hành vi đáng ghi nhận sau khi đã ship task) trong repo `quizzes`, **phải** thêm (hoặc cập nhật) mục trong **`tasks/task-NNN-*/fix-bug.md`** của task tương ứng — triệu chứng, nguyên nhân (nếu biết), cách sửa, **Đã test** (lệnh / kết quả). **Không** chỉ sửa code rồi bỏ qua file này. Đồng bộ **`e2e-test-report.md`** và test Playwright theo **`quiz-e2e-and-test-docs.mdc`** (ánh xạ bug ↔ mã kịch bản).
+
+## Dữ liệu local — **giữ** quiz / user dev (`prisma/dev.db`)
+
+Mục tiêu: làm task mới hoặc chạy `npm run verify` **không** làm mất dữ liệu người dùng đã tạo trên máy dev (trừ khi user yêu cầu reset có chủ đích).
+
+1. **Không** chạy `prisma migrate reset` (xoá toàn bộ DB + seed lại) trừ khi user **yêu cầu rõ** hoặc đang khôi phục môi trường hỏng; luôn gợi ý backup `prisma/dev.db` trước khi reset.
+2. **Migration:** tránh `DELETE` / `DROP` hàng loạt chỉ để “dọn prototype” trên nhánh dev — ưu tiên chỉ đổi schema + default / nullable; nếu bắt buộc xoá theo `type` hoặc bảng, **ghi rõ trong spec / plan** và trong PR (breaking local data). Không thêm bước script tự động xoá toàn bộ quiz ngoài phạm vi E2E.
+3. **E2E:** suite dùng **`DATABASE_URL=file:./e2e.db`** (tách `dev.db`). `global-setup` chỉ `deleteMany` quiz có `shareLink` trong `e2e/constants.ts` — **không** mở rộng xoá “tất cả quiz” hoặc toàn DB dev.
+4. Prisma CLI ngoài `package.json` (migrate, studio, …): cần `DATABASE_URL` khớp file đích (xem `.env.example`).
+
+## Task có `implementation-plan.md` (ví dụ `tasks/task-NNN-*/implementation-plan.md`)
+
+- Khi **đang code theo từng phase** trong file plan: **cập nhật realtime** bảng **§7 — Trạng thái làm theo phase** (cột *Trạng thái*, *Ngày / tham chiếu*, *e2e/verify*) và **ghi chú nhanh** nếu có blocker — để người xem PR / sau này theo dõi tiến độ không lệch thực tế.
 
 ## Feature mới — spec & tiến độ
 

--- a/.cursor/rules/quiz-e2e-and-test-docs.mdc
+++ b/.cursor/rules/quiz-e2e-and-test-docs.mdc
@@ -16,7 +16,7 @@ alwaysApply: true
 
 - **File spec theo vùng / task:** `e2e/task-NNN-mo-ta-ngan.spec.ts` (hoặc tên vùng rõ nghĩa). Nhóm `test.describe` theo task hoặc theo màn hình.
 - **Hằng số seed / share link:** `e2e/constants.ts` — **không** import từ `global-setup.ts` trong spec (tránh kéo Prisma vào test).
-- **Seed DB:** `e2e/global-setup.ts` — xóa + tạo lại quiz theo `shareLink` cần thiết; user `admin@example.com` / `e2e-seed@example.com` nếu cần.
+- **Seed DB:** `e2e/global-setup.ts` — `prisma migrate deploy` + xóa + tạo lại quiz theo `shareLink` trong `e2e/constants.ts` trên **`DATABASE_URL=file:./e2e.db`** (không ghi `dev.db`); user `admin@example.com` / `e2e-seed@example.com` nếu cần. `playwright.config.ts` đặt `reuseExistingServer: false` để không tái dùng `next start` cũ (cổng 3005) trỏ nhầm `dev.db` hoặc trạng thái cũ.
 - **Helper dùng lại:** `e2e/helpers/*.ts` (ví dụ `loginAsAdmin`).
 - **Luồng user thật trong test:** `goto`, `click`, `fill`, `selectOption`, `check`, `getByRole('button', …)` — assert kết quả hiển thị / URL; ưu tiên `getByRole` / label.
 
@@ -27,7 +27,7 @@ alwaysApply: true
 - Trong `e2e-test-report.md` (hoặc tên tương đương) giữ **hai lớp** (như task 002):
   1. **Nghiệp vụ / mã kịch bản** (bảng: mã E-, kỳ vọng, trạng thái Pass).
   2. **Chuỗi thao tác UI** — bảng hoặc mục riêng: route + các bước bấm/nhập tương ứng code Playwright (để QA và reviewer không chỉ đọc phần nghiệp vụ).
-- **Fix bug:** trong `fix-bug.md` ghi triệu chứng + nguyên nhân + cách sửa; trong **`e2e-test-report.md`** (cùng task) phải có hàng ánh xạ tới **auto test**: mã kịch bản (vd. **E3-FIX-01**), file `e2e/*.spec.ts`, và bảng **§1.2** / **§1.3** (chuỗi UI) khi thêm bước assert. Cập nhật bảng trạng thái §4. Nếu task chưa có `fix-bug.md`, có thể ghi block bug ngắn cuối `e2e-test-report.md`.
+- **Fix bug:** **bắt buộc** có (hoặc cập nhật) **`fix-bug.md`** trong `tasks/task-NNN-*/` — triệu chứng, nguyên nhân, cách sửa, đã test; trong **`e2e-test-report.md`** (cùng task) phải có hàng ánh xạ tới **auto test**: mã kịch bản, file `e2e/*.spec.ts`, và bảng **§1.2** / **§1.3** (chuỗi UI) khi thêm bước assert. Cập nhật bảng trạng thái §4. **Không** thay `fix-bug.md` bằng chỉ một block ở cuối `e2e-test-report.md` (trừ khi task cực nhỏ và team đã ghi rõ ngoại lệ trong PR).
 
 ## Sau khi thêm / sửa E2E
 

--- a/.cursor/rules/quiz-product-architecture.mdc
+++ b/.cursor/rules/quiz-product-architecture.mdc
@@ -17,7 +17,7 @@ alwaysApply: true
 |------|------------|
 | `crossword_basic` | Từ khóa chuẩn hóa (bỏ dấu, bỏ space); đúng `N` câu; mỗi đáp án chứa ký tự slot tương ứng; `letterIndex` gán server (lần xuất hiện đầu trong đáp án, bỏ qua space). |
 | `crossword_advanced` | Giống basic + hình ảnh liên quan từ khóa tổng, lật mở theo tiến độ (spec rõ trong task). |
-| `multiple_choice` | **15 câu**, mỗi câu **4 phương án**, độ khó **tăng dần** theo thứ tự (order 1–15). |
+| `multiple_choice` | **Ngân hàng** câu (mỗi câu **4 phương án**, một đúng, độ khó `easy`…`extreme`), **`playLength`** ≤ số câu; phiên chơi random theo bucket + co tỉ lệ (spec **task-004**). Màn `/play/[shareLink]` + API session không lộ đáp án trước POST chấm. |
 
 Loại mới sau này: thêm như **plugin** — cùng pattern (metadata DB + validate server + form admin + màn chơi).
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# DB Playwright (tách khỏi dev.db — không commit)
+/prisma/e2e.db
+/prisma/e2e.db-journal

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@
 
 ```bash
 npm install
-cp .env.example .env.local   # hoặc tạo .env.local với NEXTAUTH_URL, NEXTAUTH_SECRET
+cp .env.example .env.local   # gồm NEXTAUTH_*, DATABASE_URL (SQLite dev)
+# Hoặc: export DATABASE_URL="file:./dev.db" rồi chạy Prisma CLI (đường dẫn tương đối theo thư mục prisma/)
 npx prisma migrate deploy
 npx prisma db seed
 npm run dev
 ```
+
+**Hai file SQLite:** `npm run dev` / `build` / `start` dùng `DATABASE_URL=file:./dev.db` (mặc định trong `package.json`). **`npm run e2e` / `verify`** dùng `file:./e2e.db` — Playwright seed/xóa theo `shareLink` test **không** ghi đè dữ liệu trong `prisma/dev.db`.
+
+**Danh sách admin (`/`, `/quizzes`):** ẩn quiz seed E2E (user `e2e-seed@example.com` hoặc `shareLink` bắt đầu `e2e-share-`). Server test Playwright bật `SHOW_E2E_SEED_IN_DASHBOARD_LIST=1` (trong `playwright.config.ts`) để spec vẫn tìm được thẻ “E2E …”.
 
 Mở [http://localhost:3000](http://localhost:3000). Admin mặc định: `admin@example.com` (mật khẩu tùy ý theo cấu hình dev trong `authorize`).
 

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -32,3 +32,6 @@ export const E2E_SHARE_ADVANCED_WRONG = "e2e-share-advanced-wrong";
 
 /** Advanced — hai context spectator (A sai, B đúng từ khóa). */
 export const E2E_SHARE_ADVANCED_SPECTATOR = "e2e-share-advanced-spectator";
+
+/** Multiple choice — task-004 (`global-setup`). */
+export const E2E_SHARE_MC = "e2e-share-mc";

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,9 @@
 import type { FullConfig } from "@playwright/test";
+import { execFileSync } from "child_process";
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { PrismaClient } from "@prisma/client";
+import { E2E_SEED_USER_EMAIL } from "../src/lib/e2e-seed";
 import { assignLetterIndexesForBasic } from "../src/modules/quiz/validation/crossword-basic";
 import { ADVANCED_IMAGE_MIN_BYTES } from "../src/modules/quiz/validation/crossword-advanced";
 import {
@@ -13,6 +15,7 @@ import {
   E2E_SHARE_BANANA,
   E2E_SHARE_BASIC,
   E2E_SHARE_EN,
+  E2E_SHARE_MC,
   E2E_SHARE_SPACE,
   E2E_SHARE_SPECTATOR,
   E2E_SHARE_WRONG,
@@ -30,6 +33,7 @@ const ALL_SEED_SHARE_LINKS = [
   E2E_SHARE_ADVANCED_KEYWORD,
   E2E_SHARE_ADVANCED_WRONG,
   E2E_SHARE_ADVANCED_SPECTATOR,
+  E2E_SHARE_MC,
 ];
 
 const E2E_ADVANCED_QUESTIONS = [
@@ -56,6 +60,9 @@ const E2E_ADVANCED_QUESTIONS = [
   },
 ] as const;
 
+/** Tách khỏi `dev.db` — Playwright chỉ seed/xóa theo shareLink trên file này. */
+const E2E_DATABASE_URL = "file:./e2e.db";
+
 function assertAssign(
   verticalWord: string,
   drafts: Parameters<typeof assignLetterIndexesForBasic>[1]
@@ -68,6 +75,13 @@ function assertAssign(
 }
 
 async function globalSetup(_config: FullConfig) {
+  process.env.DATABASE_URL = E2E_DATABASE_URL;
+  execFileSync("npx", ["prisma", "migrate", "deploy"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+    env: { ...process.env, DATABASE_URL: E2E_DATABASE_URL },
+  });
+
   const prisma = new PrismaClient();
   try {
     const uploadsDir = join(process.cwd(), "public/uploads");
@@ -85,9 +99,9 @@ async function globalSetup(_config: FullConfig) {
     });
 
     const seedUser = await prisma.user.upsert({
-      where: { email: "e2e-seed@example.com" },
+      where: { email: E2E_SEED_USER_EMAIL },
       update: {},
-      create: { email: "e2e-seed@example.com", name: "E2E Seed", isAdmin: false },
+      create: { email: E2E_SEED_USER_EMAIL, name: "E2E Seed", isAdmin: false },
     });
 
     await prisma.quiz.deleteMany({
@@ -253,6 +267,27 @@ async function globalSetup(_config: FullConfig) {
       E2E_SHARE_ADVANCED_SPECTATOR,
       "E2E Advanced Spectator"
     );
+
+    await prisma.quiz.create({
+      data: {
+        title: "E2E Multiple Choice",
+        type: "multiple_choice",
+        shareLink: E2E_SHARE_MC,
+        playLength: 1,
+        creatorId: seedUser.id,
+        multipleChoiceQuestions: {
+          create: [
+            {
+              question: "E2E MC câu 1?",
+              options: JSON.stringify(["Đáp án đúng", "Sai 1", "Sai 2", "Sai 3"]),
+              answer: 0,
+              difficulty: "easy",
+              order: 1,
+            },
+          ],
+        },
+      },
+    });
   } finally {
     await prisma.$disconnect();
   }

--- a/e2e/task-004-mc-admin.spec.ts
+++ b/e2e/task-004-mc-admin.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/auth";
+
+test.describe("Task 004 — MC admin", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test("T004-admin-01: tạo quiz multiple choice + playLength — lưu thành công", async ({
+    page,
+  }) => {
+    await page.goto("/quizzes/create");
+    await expect(page.locator("#type")).toHaveValue("multiple_choice");
+    await page.locator("#title").fill("E2E T004 MC create");
+    await page.locator("#playLength").fill("1");
+
+    const block = page.locator("div.border.rounded-lg.p-4").first();
+    await block.locator('input[type="text"]').first().fill("Câu hỏi E2E?");
+    await block.locator("input").nth(1).fill("Một");
+    await block.locator("input").nth(2).fill("Hai");
+    await block.locator("input").nth(3).fill("Ba");
+    await block.locator("input").nth(4).fill("Bốn");
+
+    await page.getByRole("button", { name: "Tạo Quiz" }).click();
+    await expect(page).toHaveURL(/\/quizzes$/);
+    await expect(
+      page.getByRole("heading", { name: "E2E T004 MC create" }).first()
+    ).toBeVisible();
+  });
+});

--- a/e2e/task-004-mc-play.spec.ts
+++ b/e2e/task-004-mc-play.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+import { E2E_SHARE_MC } from "./constants";
+
+const SESSION_QS = "?sessionSeed=playwright-session";
+
+async function findWinningOptionIndex(
+  baseURL: string,
+  request: import("@playwright/test").APIRequestContext
+): Promise<number> {
+  const gr = await request.get(
+    `${baseURL}/api/play/${E2E_SHARE_MC}/multiple-choice-session${SESSION_QS}`
+  );
+  expect(gr.ok()).toBeTruthy();
+  const body = (await gr.json()) as { sessionSeed: string };
+  const sessionSeed = body.sessionSeed;
+  for (let i = 0; i < 4; i++) {
+    const pr = await request.post(
+      `${baseURL}/api/play/${E2E_SHARE_MC}/multiple-choice-session`,
+      {
+        data: { sessionSeed, roundIndex: 0, selectedIndex: i },
+      }
+    );
+    expect(pr.ok()).toBeTruthy();
+    const r = (await pr.json()) as { isCorrect: boolean };
+    if (r.isCorrect) return i;
+  }
+  throw new Error("No correct option index");
+}
+
+test.describe("Task 004 — MC play", () => {
+  test("T004-play-01: GET session không lộ đáp án", async ({ request, baseURL }) => {
+    const res = await request.get(
+      `${baseURL}/api/play/${E2E_SHARE_MC}/multiple-choice-session${SESSION_QS}`
+    );
+    expect(res.ok()).toBeTruthy();
+    const j = (await res.json()) as Record<string, unknown>;
+    expect(j).not.toHaveProperty("answer");
+    expect(j).not.toHaveProperty("correctIndex");
+    expect(j).not.toHaveProperty("correctOption");
+    const qs = j.questions as unknown[];
+    expect(Array.isArray(qs)).toBeTruthy();
+    expect(qs).toHaveLength(1);
+    const q0 = qs[0] as Record<string, unknown>;
+    expect(q0).not.toHaveProperty("answer");
+    expect(Array.isArray(q0.options)).toBeTruthy();
+    expect((q0.options as unknown[]).length).toBe(4);
+  });
+
+  test("T004-play-02: thắng sau khi chọn đúng (có chờ reveal)", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    test.setTimeout(25_000);
+    const winIx = await findWinningOptionIndex(baseURL!, request);
+    await page.goto(`/play/${E2E_SHARE_MC}`);
+    await expect(page.getByTestId("mc-title")).toContainText("E2E Multiple Choice");
+    await page.getByTestId(`mc-option-${winIx}`).click();
+    await expect(page.getByTestId("mc-win")).toBeVisible({ timeout: 12_000 });
+    await page.getByTestId("mc-play-again").click();
+    await expect(page.getByTestId("mc-question-text")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("T004-play-03: sai → reveal đáp án đúng (xanh) → thua + Chơi lại", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    test.setTimeout(35_000);
+    const winIx = await findWinningOptionIndex(baseURL!, request);
+    const wrongIx = (winIx + 1) % 4;
+    await page.goto(`/play/${E2E_SHARE_MC}`);
+    await page.getByTestId(`mc-option-${wrongIx}`).click();
+    const correctReveal = page.locator('[data-mc-correct-reveal="true"]');
+    await expect(correctReveal).toBeVisible({ timeout: 12_000 });
+    await expect(correctReveal).toHaveClass(/mc-blink-green/);
+    await expect(page.getByTestId("mc-game-over")).toBeVisible({ timeout: 8_000 });
+    await page.getByTestId("mc-play-again").click();
+    await expect(page.getByTestId("mc-question-text")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:fresh": "rm -rf .next && next dev",
-    "build": "next build",
+    "dev": "DATABASE_URL=file:./dev.db next dev",
+    "dev:fresh": "rm -rf .next && DATABASE_URL=file:./dev.db next dev",
+    "build": "DATABASE_URL=file:./dev.db next build",
     "start": "next start",
     "lint": "eslint .",
     "check:admin-ui-css": "node scripts/check-admin-ui-css.cjs",
-    "e2e": "playwright test",
+    "e2e": "DATABASE_URL=file:./e2e.db playwright test",
     "e2e:install": "playwright install chromium",
-    "test:unit": "vitest run",
+    "test:unit": "DATABASE_URL=file:./dev.db vitest run",
     "verify": "npm run lint && npm run build && npm run check:admin-ui-css && npm run test:unit && npm run e2e"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+    "seed": "DATABASE_URL=file:./dev.db ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.0.12",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,15 @@ export default defineConfig({
     /** Dùng `next start` để tránh `.next` dev lệch vendor chunk (vd. sonner). Cần đã `npm run build` trước khi chạy `npm run e2e` đơn lẻ; `npm run verify` đã build trước e2e. */
     command: "npm run start",
     url: "http://127.0.0.1:3005",
-    env: { PORT: "3005" },
-    reuseExistingServer: !process.env.CI,
+    env: {
+      PORT: "3005",
+      /** Cùng DB với `e2e/global-setup.ts` — không ghi đè dữ liệu trong `prisma/dev.db`. */
+      DATABASE_URL: "file:./e2e.db",
+      /** Admin list hiện quiz seed để spec tìm thẻ E2E (`listQuizzesForDashboard`). */
+      SHOW_E2E_SEED_IN_DASHBOARD_LIST: "1",
+    },
+    /** Luôn tắt reuse: server cũ có thể còn trỏ `dev.db` / trạng thái session khác với `e2e.db` sau `globalSetup`. */
+    reuseExistingServer: false,
     timeout: 60_000,
     stdout: "pipe",
     stderr: "pipe",

--- a/prisma/migrations/20260417130000_task004_multiple_choice_fields/migration.sql
+++ b/prisma/migrations/20260417130000_task004_multiple_choice_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Quiz" ADD COLUMN "playLength" INTEGER;
+
+-- AlterTable
+ALTER TABLE "MultipleChoiceQuestion" ADD COLUMN "difficulty" TEXT NOT NULL DEFAULT 'easy';
+ALTER TABLE "MultipleChoiceQuestion" ADD COLUMN "order" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,9 +8,10 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// DATABASE_URL: đường dẫn tương đối theo thư mục prisma/ — xem README và `.env.example`.
 datasource db {
   provider = "sqlite"
-  url      = "file:./dev.db"
+  url      = env("DATABASE_URL")
 }
 
 model Account {
@@ -68,6 +69,7 @@ model Quiz {
   secretWord       String?            // For crossword_advanced secret word
   imageUrl         String?            // For crossword_advanced
   advancedLayoutSeed Int?             // Seeded shuffle for R×C grid labels (task-003)
+  playLength         Int?              // multiple_choice: số câu mỗi phiên (task-004)
   shareLink        String?            @unique
   crosswordQuestions CrosswordQuestion[]
   multipleChoiceQuestions MultipleChoiceQuestion[]
@@ -102,8 +104,10 @@ model CrosswordQuestion {
 model MultipleChoiceQuestion {
   id          String   @id @default(cuid())
   question    String
-  options     String   // JSON array of options
-  answer      Int      // Index of correct answer
+  options     String   // JSON array of 4 options (canonical A–D order)
+  answer      Int      // Index 0..3 = slot đúng trong canonical options
+  difficulty  String   @default("easy") // easy | medium | hard | extreme (task-004)
+  order       Int      @default(0)
   quiz        Quiz     @relation(fields: [quizId], references: [id], onDelete: Cascade)
   quizId      String
   createdAt   DateTime @default(now())

--- a/src/app/(dashboard)/quizzes/[quizId]/edit/page.tsx
+++ b/src/app/(dashboard)/quizzes/[quizId]/edit/page.tsx
@@ -28,6 +28,9 @@ export default async function EditQuizPage({
       crosswordQuestions: {
         orderBy: { order: "asc" },
       },
+      multipleChoiceQuestions: {
+        orderBy: { order: "asc" },
+      },
     },
   });
 
@@ -63,7 +66,21 @@ export default async function EditQuizPage({
           }}
         />
       ) : (
-        <QuizForm initialData={quiz} />
+        <QuizForm
+          initialData={{
+            id: quiz.id,
+            title: quiz.title,
+            type: quiz.type,
+            playLength: quiz.playLength ?? 1,
+            questions: quiz.multipleChoiceQuestions.map((q) => ({
+              question: q.question,
+              options: JSON.parse(q.options) as string[],
+              correctOption: q.answer,
+              difficulty: q.difficulty,
+              order: q.order,
+            })),
+          }}
+        />
       )}
     </div>
   );

--- a/src/app/(dashboard)/quizzes/page.tsx
+++ b/src/app/(dashboard)/quizzes/page.tsx
@@ -1,8 +1,8 @@
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
 import QuizListView from "@/components/quizzes/QuizListView";
+import { listQuizzesForDashboard } from "@/modules/quiz/server/queries";
 
 export default async function QuizzesPage() {
   const session = await getServerSession(authOptions);
@@ -11,13 +11,7 @@ export default async function QuizzesPage() {
     redirect("/login");
   }
 
-  const quizzes = await prisma.quiz.findMany({
-    orderBy: { createdAt: "desc" },
-    include: {
-      crosswordQuestions: true,
-      creator: true,
-    },
-  });
+  const quizzes = await listQuizzesForDashboard();
 
   return <QuizListView quizzes={quizzes} user={session.user} />;
 }

--- a/src/app/api/play/[shareLink]/multiple-choice-session/route.ts
+++ b/src/app/api/play/[shareLink]/multiple-choice-session/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from "next/server";
+import { nanoid } from "nanoid";
+import { prisma } from "@/lib/prisma";
+import {
+  buildMultipleChoiceSession,
+  evaluateMcRound,
+  type McBankRow,
+} from "@/modules/quiz/lib/multiple-choice-session";
+import { isMcDifficulty } from "@/modules/quiz/validation/multiple-choice-questions";
+
+function toBankRows(
+  rows: {
+    id: string;
+    question: string;
+    options: string;
+    answer: number;
+    difficulty: string;
+  }[]
+): McBankRow[] {
+  return rows.map((q) => {
+    let opts: unknown;
+    try {
+      opts = JSON.parse(q.options);
+    } catch {
+      throw new Error("Invalid options JSON");
+    }
+    if (!Array.isArray(opts) || opts.length !== 4) {
+      throw new Error("Options must be array of 4");
+    }
+    const strs = opts.map((x) => String(x ?? "").trim());
+    if (strs.some((s) => !s)) {
+      throw new Error("Empty option");
+    }
+    if (!isMcDifficulty(q.difficulty)) {
+      throw new Error("Invalid difficulty");
+    }
+    if (!Number.isInteger(q.answer) || q.answer < 0 || q.answer > 3) {
+      throw new Error("Invalid answer index");
+    }
+    return {
+      id: q.id,
+      question: q.question,
+      options: [strs[0]!, strs[1]!, strs[2]!, strs[3]!],
+      answer: q.answer,
+      difficulty: q.difficulty,
+    };
+  });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: { shareLink: string } }
+) {
+  try {
+    const quiz = await prisma.quiz.findUnique({
+      where: { shareLink: params.shareLink },
+      include: {
+        multipleChoiceQuestions: { orderBy: { order: "asc" } },
+      },
+    });
+    if (!quiz || quiz.type !== "multiple_choice") {
+      return NextResponse.json({ message: "Not found" }, { status: 404 });
+    }
+    const pl = quiz.playLength;
+    if (!pl || pl < 1) {
+      return NextResponse.json(
+        { message: "Quiz missing playLength" },
+        { status: 500 }
+      );
+    }
+
+    const url = new URL(request.url);
+    const qpSeed = url.searchParams.get("sessionSeed");
+    const sessionSeed =
+      quiz.shareLink?.startsWith("e2e-") && qpSeed && qpSeed.length > 0
+        ? qpSeed
+        : nanoid();
+
+    const bank = toBankRows(quiz.multipleChoiceQuestions);
+    const seedKey = `${params.shareLink}:${sessionSeed}`;
+    const session = buildMultipleChoiceSession(pl, bank, seedKey);
+
+    return NextResponse.json({
+      sessionSeed,
+      title: quiz.title,
+      questions: session.items,
+    });
+  } catch (e) {
+    console.error("[MC_SESSION_GET]", e);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { shareLink: string } }
+) {
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const sessionSeed = typeof body.sessionSeed === "string" ? body.sessionSeed : "";
+    const roundIndex =
+      typeof body.roundIndex === "number"
+        ? body.roundIndex
+        : parseInt(String(body.roundIndex ?? ""), 10);
+    const selectedIndex =
+      typeof body.selectedIndex === "number"
+        ? body.selectedIndex
+        : parseInt(String(body.selectedIndex ?? ""), 10);
+
+    if (!sessionSeed) {
+      return NextResponse.json({ message: "Missing sessionSeed" }, { status: 400 });
+    }
+
+    const quiz = await prisma.quiz.findUnique({
+      where: { shareLink: params.shareLink },
+      include: {
+        multipleChoiceQuestions: { orderBy: { order: "asc" } },
+      },
+    });
+    if (!quiz || quiz.type !== "multiple_choice") {
+      return NextResponse.json({ message: "Not found" }, { status: 404 });
+    }
+    const pl = quiz.playLength;
+    if (!pl || pl < 1) {
+      return NextResponse.json(
+        { message: "Quiz missing playLength" },
+        { status: 500 }
+      );
+    }
+
+    const bank = toBankRows(quiz.multipleChoiceQuestions);
+    const seedKey = `${params.shareLink}:${sessionSeed}`;
+
+    let result;
+    try {
+      result = evaluateMcRound(pl, bank, seedKey, roundIndex, selectedIndex);
+    } catch {
+      return NextResponse.json({ message: "Invalid payload" }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      correctDisplayIndex: result.correctDisplayIndex,
+      isCorrect: result.isCorrect,
+      gameOver: result.gameOver,
+      won: result.won,
+    });
+  } catch (e) {
+    console.error("[MC_SESSION_POST]", e);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/quizzes/[quizId]/route.ts
+++ b/src/app/api/quizzes/[quizId]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
-import { normalizeCrosswordQuestions } from "@/modules/quiz/validation/crossword-questions";
+import { parseQuizCreateBody } from "@/modules/quiz/validation/quiz-create-body";
 
 export async function PUT(
   request: Request,
@@ -17,42 +17,52 @@ export async function PUT(
 
   try {
     const body = await request.json();
-    const { title, type, verticalWord, secretWord, imageUrl, questions } = body;
+    const parsed = parseQuizCreateBody(body);
+    if (!parsed.ok) {
+      return NextResponse.json({ message: parsed.message }, { status: 400 });
+    }
+
+    const d = parsed.data;
 
     await prisma.crosswordQuestion.deleteMany({
       where: { quizId: params.quizId },
     });
+    await prisma.multipleChoiceQuestion.deleteMany({
+      where: { quizId: params.quizId },
+    });
 
     const updateData: Prisma.QuizUpdateInput = {
-      title,
-      type,
-      verticalWord: verticalWord ?? null,
-      secretWord: secretWord ?? null,
-      imageUrl: imageUrl ?? null,
+      title: d.title,
+      type: d.type,
+      verticalWord: d.verticalWord ?? null,
+      secretWord: d.secretWord ?? null,
+      imageUrl: d.imageUrl ?? null,
+      playLength: d.type === "multiple_choice" ? d.playLength! : null,
     };
 
-    if (
-      type === "crossword_basic" ||
-      type === "crossword_advanced"
-    ) {
-      const norm = normalizeCrosswordQuestions(
-        questions,
-        type,
-        type === "crossword_basic" ? verticalWord : null
-      );
-      if (!norm.ok) {
-        return NextResponse.json({ message: norm.message }, { status: 400 });
-      }
-      if (type === "crossword_advanced") {
+    if (d.type === "crossword_basic" || d.type === "crossword_advanced") {
+      const norm = d.normalizedCrosswordQuestions!;
+      if (d.type === "crossword_advanced") {
         updateData.advancedLayoutSeed = Math.floor(Math.random() * 0x7fffffff);
       }
       updateData.crosswordQuestions = {
-        create: norm.questions.map((q) => ({
+        create: norm.map((q) => ({
           question: q.question,
           answer: q.answer,
           order: q.order,
           position: q.position,
           letterIndex: q.letterIndex,
+        })),
+      };
+    } else if (d.type === "multiple_choice") {
+      const norm = d.normalizedMcQuestions!;
+      updateData.multipleChoiceQuestions = {
+        create: norm.map((q) => ({
+          question: q.question,
+          options: JSON.stringify(q.options),
+          answer: q.answer,
+          difficulty: q.difficulty,
+          order: q.order,
         })),
       };
     }
@@ -62,6 +72,7 @@ export async function PUT(
       data: updateData,
       include: {
         crosswordQuestions: true,
+        multipleChoiceQuestions: true,
       },
     });
 

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -5,7 +5,6 @@ import { prisma } from "@/lib/prisma";
 import { NextResponse } from "next/server";
 import { nanoid } from "nanoid";
 import { parseQuizCreateBody } from "@/modules/quiz/validation/quiz-create-body";
-import { normalizeCrosswordQuestions } from "@/modules/quiz/validation/crossword-questions";
 
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
@@ -23,6 +22,33 @@ export async function POST(request: Request) {
 
     const { data } = parsed;
     const shareLink = nanoid();
+
+    if (data.type === "multiple_choice") {
+      const norm = data.normalizedMcQuestions!;
+      const quiz = await prisma.quiz.create({
+        data: {
+          title: data.title,
+          type: data.type,
+          shareLink,
+          playLength: data.playLength!,
+          creatorId: session.user.id,
+          multipleChoiceQuestions: {
+            create: norm.map((q) => ({
+              question: q.question,
+              options: JSON.stringify(q.options),
+              answer: q.answer,
+              difficulty: q.difficulty,
+              order: q.order,
+            })),
+          },
+        },
+        include: {
+          multipleChoiceQuestions: true,
+          crosswordQuestions: true,
+        },
+      });
+      return NextResponse.json(quiz);
+    }
 
     if (data.type === "crossword_basic" || data.type === "crossword_advanced") {
       const norm = data.normalizedCrosswordQuestions!;
@@ -57,19 +83,10 @@ export async function POST(request: Request) {
       return NextResponse.json(quiz);
     }
 
-    const quiz = await prisma.quiz.create({
-      data: {
-        title: data.title,
-        type: data.type,
-        shareLink,
-        creatorId: session.user.id,
-      },
-      include: {
-        crosswordQuestions: true,
-      },
-    });
-
-    return NextResponse.json(quiz);
+    return NextResponse.json(
+      { message: "Loại quiz không được hỗ trợ." },
+      { status: 400 }
+    );
   } catch (error) {
     console.error("[QUIZ_CREATE]", error);
     return new NextResponse("Internal Error", { status: 500 });
@@ -85,43 +102,53 @@ export async function PUT(request: Request) {
 
   try {
     const body = await request.json();
-    const { id, title, type, verticalWord, secretWord, imageUrl, questions } = body;
-
-    if (!id || !title || !type) {
-      return new NextResponse("Missing required fields", { status: 400 });
+    const id = typeof (body as { id?: unknown }).id === "string" ? (body as { id: string }).id : "";
+    if (!id) {
+      return new NextResponse("Missing quiz id", { status: 400 });
     }
 
-    await prisma.crosswordQuestion.deleteMany({
-      where: { quizId: id },
-    });
+    const parsed = parseQuizCreateBody(body);
+    if (!parsed.ok) {
+      return NextResponse.json({ message: parsed.message }, { status: 400 });
+    }
+
+    const d = parsed.data;
+
+    await prisma.crosswordQuestion.deleteMany({ where: { quizId: id } });
+    await prisma.multipleChoiceQuestion.deleteMany({ where: { quizId: id } });
 
     const updateData: Prisma.QuizUpdateInput = {
-      title,
-      type,
-      verticalWord: verticalWord ?? null,
-      secretWord: secretWord ?? null,
-      imageUrl: imageUrl ?? null,
+      title: d.title,
+      type: d.type,
+      verticalWord: d.verticalWord ?? null,
+      secretWord: d.secretWord ?? null,
+      imageUrl: d.imageUrl ?? null,
+      playLength: d.type === "multiple_choice" ? d.playLength! : null,
     };
 
-    if (type === "crossword_basic" || type === "crossword_advanced") {
-      const norm = normalizeCrosswordQuestions(
-        questions,
-        type,
-        type === "crossword_basic" ? verticalWord : null
-      );
-      if (!norm.ok) {
-        return NextResponse.json({ message: norm.message }, { status: 400 });
-      }
-      if (type === "crossword_advanced") {
+    if (d.type === "crossword_basic" || d.type === "crossword_advanced") {
+      const norm = d.normalizedCrosswordQuestions!;
+      if (d.type === "crossword_advanced") {
         updateData.advancedLayoutSeed = Math.floor(Math.random() * 0x7fffffff);
       }
       updateData.crosswordQuestions = {
-        create: norm.questions.map((q) => ({
+        create: norm.map((q) => ({
           question: q.question,
           answer: q.answer,
           order: q.order,
           position: q.position,
           letterIndex: q.letterIndex,
+        })),
+      };
+    } else if (d.type === "multiple_choice") {
+      const norm = d.normalizedMcQuestions!;
+      updateData.multipleChoiceQuestions = {
+        create: norm.map((q) => ({
+          question: q.question,
+          options: JSON.stringify(q.options),
+          answer: q.answer,
+          difficulty: q.difficulty,
+          order: q.order,
         })),
       };
     }
@@ -131,6 +158,7 @@ export async function PUT(request: Request) {
       data: updateData,
       include: {
         crosswordQuestions: true,
+        multipleChoiceQuestions: true,
       },
     });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,3 +18,38 @@ body {
   background: var(--background);
   color: var(--foreground);
 }
+
+/* Multiple choice — nhấp nháy làm nổi bật đáp án đúng (player) */
+@keyframes mc-blink-green-amber {
+  0%,
+  100% {
+    background-color: rgb(209 250 229);
+    border-color: rgb(52 211 153);
+    box-shadow: 0 0 0 2px rgb(251 191 36 / 0.45);
+  }
+  50% {
+    background-color: rgb(254 243 199);
+    border-color: rgb(245 158 11);
+    box-shadow: 0 0 0 2px rgb(16 185 129 / 0.35);
+  }
+}
+
+@keyframes mc-blink-green {
+  0%,
+  100% {
+    background-color: rgb(209 250 229);
+    border-color: rgb(16 185 129);
+  }
+  50% {
+    background-color: rgb(167 243 208);
+    border-color: rgb(5 150 105);
+  }
+}
+
+.mc-blink-green-amber {
+  animation: mc-blink-green-amber 0.55s ease-in-out infinite;
+}
+
+.mc-blink-green {
+  animation: mc-blink-green 0.5s ease-in-out infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
 import QuizListView from "@/components/quizzes/QuizListView";
+import { listQuizzesForDashboard } from "@/modules/quiz/server/queries";
 
 export default async function Home() {
   const session = await getServerSession(authOptions);
@@ -15,13 +15,7 @@ export default async function Home() {
     redirect("/quizzes");
   }
 
-  const quizzes = await prisma.quiz.findMany({
-    orderBy: { createdAt: "desc" },
-    include: {
-      crosswordQuestions: true,
-      creator: true,
-    },
-  });
+  const quizzes = await listQuizzesForDashboard();
 
   return <QuizListView quizzes={quizzes} user={session.user} />;
 }

--- a/src/app/play/[shareLink]/page.tsx
+++ b/src/app/play/[shareLink]/page.tsx
@@ -4,6 +4,7 @@ import {
   isKeywordGloballySolved,
 } from "@/modules/quiz/server/queries";
 import CrosswordPlayer from "@/modules/quiz/components/player/CrosswordPlayer";
+import MultipleChoicePlayer from "@/modules/quiz/components/player/MultipleChoicePlayer";
 import { quizTypeSupportsCrosswordPlayer } from "@/modules/quiz/registry";
 
 export default async function PublicPlayPage({
@@ -29,6 +30,14 @@ export default async function PublicPlayPage({
           playShareLink={params.shareLink}
           keywordGloballySolved={keywordGloballySolved}
         />
+      </div>
+    );
+  }
+
+  if (quiz.type === "multiple_choice") {
+    return (
+      <div className="container mx-auto py-8 px-4 max-w-2xl">
+        <MultipleChoicePlayer shareLink={params.shareLink} title={quiz.title} />
       </div>
     );
   }

--- a/src/components/quizzes/QuizForm.tsx
+++ b/src/components/quizzes/QuizForm.tsx
@@ -15,10 +15,25 @@ import {
 
 interface Question {
   question: string
-  answer: string
+  answer?: string
   order?: number
-  options?: string[] // for multiple choice
-  correctOption?: number // for multiple choice
+  options?: string[]
+  correctOption?: number
+  difficulty?: string
+}
+
+function defaultMcQuestion(order = 1): Question {
+  return {
+    question: "",
+    options: ["", "", "", ""],
+    correctOption: 0,
+    difficulty: "easy",
+    order,
+  }
+}
+
+function defaultCrosswordQuestion(order = 1): Question {
+  return { question: "", answer: "", order }
 }
 
 interface QuizFormProps {
@@ -28,14 +43,23 @@ interface QuizFormProps {
 export default function QuizForm({ initialData }: QuizFormProps) {
   const router = useRouter()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const initialType = initialData?.type || "multiple_choice"
+  const initialQuestions: Question[] =
+    initialData?.questions && Array.isArray(initialData.questions)
+      ? initialData.questions
+      : initialType === "multiple_choice"
+        ? [defaultMcQuestion(1)]
+        : [defaultCrosswordQuestion(1)]
   const [formData, setFormData] = useState({
     title: initialData?.title || "",
-    type: initialData?.type || "multiple_choice",
+    type: initialType,
     verticalWord: initialData?.verticalWord || "",
     secretWord: initialData?.secretWord || "",
     imageUrl: initialData?.imageUrl || "",
     imageFile: null as File | null,
-    questions: initialData?.questions || [{ question: "", answer: "", order: 1 }]
+    playLength:
+      typeof initialData?.playLength === "number" ? initialData.playLength : 1,
+    questions: initialQuestions,
   })
   const [error, setError] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -47,7 +71,7 @@ export default function QuizForm({ initialData }: QuizFormProps) {
     }
     const drafts = formData.questions.map((q: Question, i: number) => ({
       question: q.question,
-      answer: q.answer,
+      answer: String(q.answer ?? "").trim(),
       order: i + 1,
       position: i + 1,
     }))
@@ -55,16 +79,14 @@ export default function QuizForm({ initialData }: QuizFormProps) {
   }, [formData.type, formData.verticalWord, formData.questions])
 
   const handleAddQuestion = () => {
+    const nextOrder = formData.questions.length + 1
+    const blank: Question =
+      formData.type === "multiple_choice"
+        ? defaultMcQuestion(nextOrder)
+        : defaultCrosswordQuestion(nextOrder)
     setFormData({
       ...formData,
-      questions: [
-        ...formData.questions,
-        {
-          question: "",
-          answer: "",
-          order: formData.questions.length + 1
-        }
-      ]
+      questions: [...formData.questions, blank],
     })
   }
 
@@ -72,12 +94,34 @@ export default function QuizForm({ initialData }: QuizFormProps) {
     const newQuestions = [...formData.questions]
     newQuestions[index] = {
       ...newQuestions[index],
-      [field]: value
+      [field]: value,
     }
     setFormData({
       ...formData,
-      questions: newQuestions
+      questions: newQuestions,
     })
+  }
+
+  const handleMcOptionChange = (qIndex: number, optIndex: number, value: string) => {
+    const newQuestions = [...formData.questions]
+    const prev = newQuestions[qIndex]!
+    const opts = [...(prev.options || ["", "", "", ""])]
+    opts[optIndex] = value
+    newQuestions[qIndex] = { ...prev, options: opts }
+    setFormData({ ...formData, questions: newQuestions })
+  }
+
+  const handleMcNumberChange = (
+    index: number,
+    field: "correctOption" | "difficulty",
+    value: number | string
+  ) => {
+    const newQuestions = [...formData.questions]
+    newQuestions[index] = {
+      ...newQuestions[index]!,
+      [field]: value,
+    }
+    setFormData({ ...formData, questions: newQuestions })
   }
 
   const handleRemoveQuestion = (index: number) => {
@@ -188,6 +232,17 @@ export default function QuizForm({ initialData }: QuizFormProps) {
         }))
       }
 
+      if (formData.type === "multiple_choice") {
+        quizData.playLength = formData.playLength
+        quizData.questions = formData.questions.map((q: Question, i: number) => ({
+          question: String(q.question || "").trim(),
+          options: (q.options || ["", "", "", ""]).map((x) => String(x || "").trim()),
+          answer: q.correctOption ?? 0,
+          difficulty: q.difficulty || "easy",
+          order: i + 1,
+        }))
+      }
+
       // Gửi dữ liệu quiz với URL hình ảnh đã được upload (nếu có)
       const response = await fetch(`/api/quizzes${initialData?.id ? `/${initialData.id}` : ""}`, {
         method: initialData?.id ? "PUT" : "POST",
@@ -241,7 +296,18 @@ export default function QuizForm({ initialData }: QuizFormProps) {
         <select
           id="type"
           value={formData.type}
-          onChange={(e) => setFormData({ ...formData, type: e.target.value })}
+          onChange={(e) => {
+            const t = e.target.value
+            setFormData({
+              ...formData,
+              type: t,
+              questions:
+                t === "multiple_choice"
+                  ? [defaultMcQuestion(1)]
+                  : [defaultCrosswordQuestion(1)],
+              playLength: t === "multiple_choice" ? 1 : formData.playLength,
+            })
+          }}
           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
           disabled={!!initialData}
         >
@@ -474,6 +540,135 @@ export default function QuizForm({ initialData }: QuizFormProps) {
                   <p className="mt-1 text-sm text-gray-500">
                     Mỗi khi người chơi trả lời đúng một câu hỏi, một phần của hình ảnh sẽ được hiện ra
                   </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {formData.type === "multiple_choice" && (
+        <>
+          <div>
+            <label htmlFor="playLength" className="block text-sm font-medium text-gray-700">
+              Số câu trong một lần chơi (≤ số câu trong ngân hàng)
+            </label>
+            <input
+              type="number"
+              id="playLength"
+              min={1}
+              max={formData.questions.length || 1}
+              value={formData.playLength}
+              onChange={(e) => {
+                const n = Math.max(1, parseInt(e.target.value, 10) || 1)
+                const cap = Math.max(1, formData.questions.length)
+                setFormData({ ...formData, playLength: Math.min(n, cap) })
+              }}
+              className="mt-1 block w-full max-w-xs rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              required
+            />
+            <p className="mt-1 text-sm text-gray-500">
+              Ngân hàng hiện có {formData.questions.length} câu.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-lg font-medium">Ngân hàng câu hỏi</h3>
+
+            {formData.questions.map((question: Question, index: number) => (
+              <div key={index} className="border rounded-lg p-4 space-y-4">
+                <div className="flex justify-between items-center">
+                  <span className="font-medium">Câu hỏi #{index + 1}</span>
+                  {formData.questions.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveQuestion(index)}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      Xóa
+                    </button>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    Nội dung câu hỏi
+                  </label>
+                  <input
+                    type="text"
+                    value={question.question}
+                    onChange={(e) => handleQuestionChange(index, "question", e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    required
+                  />
+                </div>
+
+                <div>
+                  <span className="block text-sm font-medium text-gray-700 mb-2">
+                    Bốn phương án (A–D)
+                  </span>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {(["A", "B", "C", "D"] as const).map((lab, oi) => (
+                      <div key={lab}>
+                        <label className="text-xs text-gray-600">{lab}</label>
+                        <input
+                          type="text"
+                          value={(question.options || ["", "", "", ""])[oi] || ""}
+                          onChange={(e) => handleMcOptionChange(index, oi, e.target.value)}
+                          className="mt-0.5 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                          required
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <span className="block text-sm font-medium text-gray-700 mb-2">
+                    Đáp án đúng
+                  </span>
+                  <div className="flex flex-wrap gap-3">
+                    {([0, 1, 2, 3] as const).map((ci) => (
+                      <label key={ci} className="inline-flex items-center gap-1 text-sm">
+                        <input
+                          type="radio"
+                          name={`correct-${index}`}
+                          checked={(question.correctOption ?? 0) === ci}
+                          onChange={() => handleMcNumberChange(index, "correctOption", ci)}
+                        />
+                        {["A", "B", "C", "D"][ci]}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700">
+                    Độ khó
+                  </label>
+                  <select
+                    value={question.difficulty || "easy"}
+                    onChange={(e) =>
+                      handleMcNumberChange(index, "difficulty", e.target.value)
+                    }
+                    className="mt-1 block w-full max-w-md rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                  >
+                    <option value="easy">Dễ</option>
+                    <option value="medium">Trung bình</option>
+                    <option value="hard">Khó</option>
+                    <option value="extreme">Siêu khó</option>
+                  </select>
+                </div>
+
+                <div className="pt-3 border-t border-gray-100">
+                  <button
+                    type="button"
+                    onClick={handleAddQuestion}
+                    className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+                    data-testid="mc-add-question-after-card"
+                  >
+                    + Thêm câu hỏi
+                  </button>
                 </div>
               </div>
             ))}

--- a/src/lib/e2e-seed.ts
+++ b/src/lib/e2e-seed.ts
@@ -1,0 +1,21 @@
+import type { Prisma } from "@prisma/client";
+
+/** User tạo quiz seed trong `e2e/global-setup.ts` — trùng email trong setup. */
+export const E2E_SEED_USER_EMAIL = "e2e-seed@example.com" as const;
+
+/** Prefix `shareLink` của mọi bài seed Playwright (`e2e/constants.ts`). */
+export const E2E_SHARE_LINK_PREFIX = "e2e-share-" as const;
+
+/**
+ * Loại quiz seed E2E khỏi danh sách dashboard (admin `/` và `/quizzes`).
+ * Dùng khi dev.db còn bản ghi test hoặc khi DB dev/e2e dùng chung nhầm.
+ * Playwright bật `SHOW_E2E_SEED_IN_DASHBOARD_LIST=1` trên `next start` để spec vẫn thấy thẻ seed.
+ */
+export const whereQuizExcludingE2eSeed: Prisma.QuizWhereInput = {
+  NOT: {
+    OR: [
+      { creator: { email: E2E_SEED_USER_EMAIL } },
+      { shareLink: { startsWith: E2E_SHARE_LINK_PREFIX } },
+    ],
+  },
+};

--- a/src/modules/quiz/components/player/MultipleChoicePlayer.tsx
+++ b/src/modules/quiz/components/player/MultipleChoicePlayer.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type SessionPayload = {
+  sessionSeed: string;
+  title: string;
+  questions: { question: string; options: string[] }[];
+};
+
+const REVEAL_MS = 5000;
+
+export default function MultipleChoicePlayer({
+  shareLink,
+  title: titleProp,
+}: {
+  shareLink: string;
+  title?: string;
+}) {
+  const [title, setTitle] = useState(titleProp ?? "");
+  const [sessionSeed, setSessionSeed] = useState<string | null>(null);
+  const [questions, setQuestions] = useState<SessionPayload["questions"]>([]);
+  const [roundIndex, setRoundIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [locked, setLocked] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+  const [correctDisplayIndex, setCorrectDisplayIndex] = useState<number | null>(
+    null
+  );
+  const [gameOver, setGameOver] = useState(false);
+  const [won, setWon] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSession = useCallback(
+    async (fixedSeed?: string) => {
+      setLoading(true);
+      setError(null);
+      setGameOver(false);
+      setWon(false);
+      setRoundIndex(0);
+      setSelectedIndex(null);
+      setLocked(false);
+      setRevealed(false);
+      setCorrectDisplayIndex(null);
+      try {
+        const q = fixedSeed
+          ? `?sessionSeed=${encodeURIComponent(fixedSeed)}`
+          : "";
+        const res = await fetch(
+          `/api/play/${encodeURIComponent(shareLink)}/multiple-choice-session${q}`
+        );
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}));
+          throw new Error(
+            typeof j.message === "string" ? j.message : "Không tải được phiên chơi"
+          );
+        }
+        const data = (await res.json()) as SessionPayload;
+        setSessionSeed(data.sessionSeed);
+        setTitle(data.title);
+        setQuestions(data.questions);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Lỗi tải phiên");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [shareLink]
+  );
+
+  useEffect(() => {
+    void loadSession(
+      shareLink.startsWith("e2e-") ? "playwright-session" : undefined
+    );
+  }, [loadSession, shareLink]);
+
+  const current = questions[roundIndex];
+  const showOptionsBlock =
+    Boolean(current) && !won && (!gameOver || (gameOver && revealed));
+
+  const handlePick = async (idx: number) => {
+    if (locked || gameOver || won || !sessionSeed || !current) return;
+    setLocked(true);
+    setSelectedIndex(idx);
+
+    let revealPayload: {
+      correctDisplayIndex: number;
+      isCorrect: boolean;
+      gameOver: boolean;
+      won: boolean;
+    };
+    try {
+      const res = await fetch(
+        `/api/play/${encodeURIComponent(shareLink)}/multiple-choice-session`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionSeed,
+            roundIndex,
+            selectedIndex: idx,
+          }),
+        }
+      );
+      if (!res.ok) {
+        throw new Error("Không gửi được đáp án");
+      }
+      revealPayload = (await res.json()) as typeof revealPayload;
+    } catch {
+      setError("Lỗi máy chủ khi chấm đáp án");
+      setLocked(false);
+      setSelectedIndex(null);
+      return;
+    }
+
+    await new Promise((r) => setTimeout(r, REVEAL_MS));
+    setCorrectDisplayIndex(revealPayload.correctDisplayIndex);
+    setRevealed(true);
+
+    if (!revealPayload.isCorrect) {
+      /** Spec: sau reveal vẫn thấy đáp án đúng (xanh nhạt + nhấp nháy) rồi mới kết thúc. */
+      await new Promise((r) => setTimeout(r, 2800));
+      setGameOver(true);
+      return;
+    }
+    if (revealPayload.won) {
+      /** Giữ lưới đáp án một lúc để thấy nhấp nháy xanh/cam rồi mới chuyển màn thắng. */
+      await new Promise((r) => setTimeout(r, 1800));
+      setWon(true);
+      return;
+    }
+    setTimeout(() => {
+      setRoundIndex((r) => r + 1);
+      setSelectedIndex(null);
+      setLocked(false);
+      setRevealed(false);
+      setCorrectDisplayIndex(null);
+    }, 1500);
+  };
+
+  const playAgain = () => {
+    void loadSession(shareLink.startsWith("e2e-") ? "playwright-session" : undefined);
+  };
+
+  if (loading && questions.length === 0) {
+    return (
+      <div className="text-gray-600" data-testid="mc-loading">
+        Đang tải…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-red-600" data-testid="mc-error">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold" data-testid="mc-title">
+        {title}
+      </h1>
+
+      {won && (
+        <div
+          className="rounded-lg border border-green-200 bg-green-50 p-6 text-center space-y-4"
+          data-testid="mc-win"
+        >
+          <p className="text-lg font-semibold text-green-900">
+            Bạn là người chiến thắng
+          </p>
+          <button
+            type="button"
+            onClick={playAgain}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"
+            data-testid="mc-play-again"
+          >
+            Chơi lại
+          </button>
+        </div>
+      )}
+
+      {showOptionsBlock && current && (
+        <>
+          <p className="text-sm text-gray-500">
+            Câu {roundIndex + 1} / {questions.length}
+          </p>
+          <p className="text-lg" data-testid="mc-question-text">
+            {current.question}
+          </p>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {current.options.map((label, idx) => {
+              const isSelected = selectedIndex === idx;
+              const isCorrectSlot =
+                revealed && correctDisplayIndex !== null && idx === correctDisplayIndex;
+              const blinkGreenAmber = revealed && isCorrectSlot && isSelected;
+              const blinkGreenOnly = revealed && isCorrectSlot && !isSelected;
+
+              let ring = "border-gray-300";
+              if (revealed && isCorrectSlot) {
+                ring = blinkGreenAmber
+                  ? "border-emerald-400 bg-emerald-50"
+                  : "border-emerald-500 bg-emerald-50";
+              } else if (isSelected && !revealed) {
+                ring = "border-amber-500 bg-amber-50";
+              } else if (revealed && isSelected && !isCorrectSlot) {
+                ring = "border-amber-500 bg-amber-50";
+              }
+
+              const blinkClass = blinkGreenAmber
+                ? "mc-blink-green-amber"
+                : blinkGreenOnly
+                  ? "mc-blink-green"
+                  : "";
+
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  disabled={locked || won || gameOver}
+                  data-testid={`mc-option-${idx}`}
+                  data-mc-correct-reveal={
+                    revealed && isCorrectSlot ? "true" : undefined
+                  }
+                  aria-pressed={isSelected}
+                  onClick={() => handlePick(idx)}
+                  className={`rounded-lg border-2 p-4 text-left transition ${ring} ${blinkClass} disabled:cursor-not-allowed disabled:opacity-60`}
+                >
+                  <span className="sr-only">Phương án {idx + 1}.</span>
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {gameOver && (
+        <div
+          className="rounded-lg border border-red-200 bg-red-50 p-6 text-center space-y-4"
+          data-testid="mc-game-over"
+        >
+          <p className="text-lg font-semibold text-red-900">Bạn đã thua</p>
+          <button
+            type="button"
+            onClick={playAgain}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"
+            data-testid="mc-play-again"
+          >
+            Chơi lại
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/quiz/lib/multiple-choice-session.test.ts
+++ b/src/modules/quiz/lib/multiple-choice-session.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMultipleChoiceSession,
+  computeBucketCounts,
+  difficultyForPosition,
+  evaluateMcRound,
+  type McBankRow,
+} from "./multiple-choice-session";
+
+describe("computeBucketCounts", () => {
+  it("L=8 matches Hamilton 3+2+2+1", () => {
+    expect(computeBucketCounts(8)).toEqual({
+      easy: 3,
+      medium: 2,
+      hard: 2,
+      extreme: 1,
+    });
+  });
+
+  it("L=13 is 4+4+4+1", () => {
+    expect(computeBucketCounts(13)).toEqual({
+      easy: 4,
+      medium: 4,
+      hard: 4,
+      extreme: 1,
+    });
+  });
+
+  it("L=20 extends extreme only", () => {
+    expect(computeBucketCounts(20)).toEqual({
+      easy: 4,
+      medium: 4,
+      hard: 4,
+      extreme: 8,
+    });
+  });
+
+  it("L=1 assigns one bucket via remainder", () => {
+    const c = computeBucketCounts(1);
+    expect(c.easy + c.medium + c.hard + c.extreme).toBe(1);
+  });
+});
+
+describe("difficultyForPosition", () => {
+  it("maps positions for L=8", () => {
+    const c = computeBucketCounts(8);
+    expect(difficultyForPosition(1, c)).toBe("easy");
+    expect(difficultyForPosition(3, c)).toBe("easy");
+    expect(difficultyForPosition(4, c)).toBe("medium");
+    expect(difficultyForPosition(8, c)).toBe("extreme");
+  });
+});
+
+function bankFixture(): McBankRow[] {
+  const mk = (
+    id: string,
+    d: McBankRow["difficulty"],
+    letter: string
+  ): McBankRow => ({
+    id,
+    question: `Q-${id}`,
+    options: [`${letter}0`, `${letter}1`, `${letter}2`, `${letter}3`],
+    answer: 0,
+    difficulty: d,
+  });
+  return [
+    mk("e1", "easy", "E"),
+    mk("e2", "easy", "F"),
+    mk("m1", "medium", "M"),
+    mk("m2", "medium", "N"),
+    mk("h1", "hard", "H"),
+    mk("h2", "hard", "I"),
+    mk("x1", "extreme", "X"),
+    mk("x2", "extreme", "Y"),
+  ];
+}
+
+describe("buildMultipleChoiceSession", () => {
+  it("is deterministic for same seedKey", () => {
+    const b = bankFixture();
+    const a = buildMultipleChoiceSession(4, b, "seed-a");
+    const b2 = buildMultipleChoiceSession(4, b, "seed-a");
+    expect(a.items).toEqual(b2.items);
+    expect(a.correctDisplayIndices).toEqual(b2.correctDisplayIndices);
+  });
+
+  it("allows repeat when pool exhausted (single easy)", () => {
+    const oneEasy: McBankRow[] = [
+      {
+        id: "only",
+        question: "Lonely",
+        options: ["a", "b", "c", "d"],
+        answer: 2,
+        difficulty: "easy",
+      },
+    ];
+    const s = buildMultipleChoiceSession(3, oneEasy, "repeat-seed");
+    expect(s.items).toHaveLength(3);
+  });
+});
+
+describe("evaluateMcRound", () => {
+  it("detects wrong answer", () => {
+    const b = bankFixture();
+    const key = "eval-seed-1";
+    const built = buildMultipleChoiceSession(2, b, key);
+    const wrong = (built.correctDisplayIndices[0]! + 1) % 4;
+    const r = evaluateMcRound(2, b, key, 0, wrong);
+    expect(r.isCorrect).toBe(false);
+    expect(r.gameOver).toBe(true);
+    expect(r.won).toBe(false);
+  });
+
+  it("detects win on last question", () => {
+    const one: McBankRow[] = [
+      {
+        id: "a",
+        question: "Only",
+        options: ["a", "b", "c", "d"],
+        answer: 1,
+        difficulty: "easy",
+      },
+    ];
+    const key = "win-seed";
+    const built = buildMultipleChoiceSession(1, one, key);
+    const good = built.correctDisplayIndices[0]!;
+    const r = evaluateMcRound(1, one, key, 0, good);
+    expect(r.isCorrect).toBe(true);
+    expect(r.gameOver).toBe(false);
+    expect(r.won).toBe(true);
+  });
+});

--- a/src/modules/quiz/lib/multiple-choice-session.ts
+++ b/src/modules/quiz/lib/multiple-choice-session.ts
@@ -1,0 +1,206 @@
+import type { McDifficulty } from "../validation/multiple-choice-questions";
+
+export const MC_BUCKET_ORDER: McDifficulty[] = [
+  "easy",
+  "medium",
+  "hard",
+  "extreme",
+];
+
+export type McBankRow = {
+  id: string;
+  question: string;
+  /** Canonical four strings (slot A–D). */
+  options: [string, string, string, string];
+  /** 0..3 index into canonical options. */
+  answer: number;
+  difficulty: McDifficulty;
+};
+
+export type McPublicQuestion = {
+  question: string;
+  options: string[];
+};
+
+export type McBuiltSession = {
+  playLength: number;
+  items: McPublicQuestion[];
+  /** Parallel to items — not sent to client. */
+  correctDisplayIndices: number[];
+};
+
+/** Largest remainder (Hamilton) for L < 13; fixed bands for L ≥ 13. */
+export function computeBucketCounts(L: number): {
+  easy: number;
+  medium: number;
+  hard: number;
+  extreme: number;
+} {
+  if (!Number.isInteger(L) || L < 1) {
+    throw new Error("playLength must be a positive integer");
+  }
+  if (L >= 13) {
+    return { easy: 4, medium: 4, hard: 4, extreme: L - 12 };
+  }
+  const weights = [4, 4, 4, 1] as const;
+  const W = 13;
+  const raw = weights.map((w) => (L * w) / W);
+  const floors = raw.map((x) => Math.floor(x));
+  const counts = [...floors] as [number, number, number, number];
+  let remainder = L - floors.reduce((a, b) => a + b, 0);
+  const orderIdx = [0, 1, 2, 3].sort((a, b) => {
+    const fa = raw[a] - floors[a];
+    const fb = raw[b] - floors[b];
+    if (fb !== fa) return fb - fa;
+    return a - b;
+  });
+  for (let k = 0; k < remainder; k++) {
+    counts[orderIdx[k]!] += 1;
+  }
+  return {
+    easy: counts[0]!,
+    medium: counts[1]!,
+    hard: counts[2]!,
+    extreme: counts[3]!,
+  };
+}
+
+/** 1-based position → bucket difficulty. */
+export function difficultyForPosition(
+  positionOneBased: number,
+  counts: ReturnType<typeof computeBucketCounts>
+): McDifficulty {
+  if (positionOneBased <= counts.easy) return "easy";
+  if (positionOneBased <= counts.easy + counts.medium) return "medium";
+  if (
+    positionOneBased <=
+    counts.easy + counts.medium + counts.hard
+  ) {
+    return "hard";
+  }
+  return "extreme";
+}
+
+export function hashSeedToUint32(seed: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function createSeededRng(seed: string): () => number {
+  let a = hashSeedToUint32(seed);
+  if (a === 0) a = 0x9e3779b9;
+  return function mulberry32() {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function shuffleOptions(
+  canonicalFour: [string, string, string, string],
+  correctIndex: number,
+  rng: () => number
+): { displayOptions: string[]; correctDisplayIndex: number } {
+  const order = [0, 1, 2, 3];
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [order[i], order[j]] = [order[j]!, order[i]!];
+  }
+  const displayOptions = order.map((ix) => canonicalFour[ix]!);
+  const correctDisplayIndex = order.indexOf(correctIndex);
+  return { displayOptions, correctDisplayIndex };
+}
+
+function pickQuestionForBucket(
+  bank: McBankRow[],
+  difficulty: McDifficulty,
+  usedIds: Set<string>,
+  rng: () => number
+): McBankRow {
+  let pool = bank.filter((q) => q.difficulty === difficulty);
+  /** Spec: không bắt buộc đủ pool — nếu bucket trống thì lấy từ toàn bộ ngân hàng. */
+  if (pool.length === 0) {
+    pool = [...bank];
+  }
+  if (pool.length === 0) {
+    throw new Error("No questions in bank");
+  }
+  const available = pool.filter((q) => !usedIds.has(q.id));
+  const source = available.length > 0 ? available : pool;
+  const pick = source[Math.floor(rng() * source.length)]!;
+  if (available.length > 0) {
+    usedIds.add(pick.id);
+  }
+  return pick;
+}
+
+/**
+ * @param seedKey — stable string (e.g. shareLink + ":" + sessionSeed) so GET/POST can recompute the same session.
+ */
+export function buildMultipleChoiceSession(
+  playLength: number,
+  bank: McBankRow[],
+  seedKey: string
+): McBuiltSession {
+  const rng = createSeededRng(seedKey);
+  const counts = computeBucketCounts(playLength);
+  const usedIds = new Set<string>();
+  const picks: McBankRow[] = [];
+  for (let pos = 1; pos <= playLength; pos++) {
+    const diff = difficultyForPosition(pos, counts);
+    picks.push(pickQuestionForBucket(bank, diff, usedIds, rng));
+  }
+
+  const items: McPublicQuestion[] = [];
+  const correctDisplayIndices: number[] = [];
+  for (const row of picks) {
+    const { displayOptions, correctDisplayIndex } = shuffleOptions(
+      row.options,
+      row.answer,
+      rng
+    );
+    items.push({ question: row.question, options: displayOptions });
+    correctDisplayIndices.push(correctDisplayIndex);
+  }
+
+  return { playLength, items, correctDisplayIndices };
+}
+
+export function evaluateMcRound(
+  playLength: number,
+  bank: McBankRow[],
+  seedKey: string,
+  roundIndex: number,
+  selectedIndex: number
+): {
+  correctDisplayIndex: number;
+  isCorrect: boolean;
+  gameOver: boolean;
+  won: boolean;
+} {
+  if (
+    !Number.isInteger(roundIndex) ||
+    roundIndex < 0 ||
+    roundIndex >= playLength
+  ) {
+    throw new Error("Invalid roundIndex");
+  }
+  if (!Number.isInteger(selectedIndex) || selectedIndex < 0 || selectedIndex > 3) {
+    throw new Error("Invalid selectedIndex");
+  }
+  const built = buildMultipleChoiceSession(playLength, bank, seedKey);
+  const correctDisplayIndex = built.correctDisplayIndices[roundIndex]!;
+  const isCorrect = selectedIndex === correctDisplayIndex;
+  const isLast = roundIndex === built.items.length - 1;
+  return {
+    correctDisplayIndex,
+    isCorrect,
+    gameOver: !isCorrect,
+    won: isCorrect && isLast,
+  };
+}

--- a/src/modules/quiz/server/queries.ts
+++ b/src/modules/quiz/server/queries.ts
@@ -1,9 +1,37 @@
 import { prisma } from "@/lib/prisma";
-import type { CrosswordQuestion, Quiz } from "@prisma/client";
+import { whereQuizExcludingE2eSeed } from "@/lib/e2e-seed";
+import type {
+  CrosswordQuestion,
+  MultipleChoiceQuestion,
+  Quiz,
+  User,
+} from "@prisma/client";
 
 export type QuizWithCrossword = Quiz & {
   crosswordQuestions: CrosswordQuestion[];
+  multipleChoiceQuestions?: MultipleChoiceQuestion[];
 };
+
+/** Danh sách quiz cho `QuizListView` — không gồm seed Playwright. */
+export type QuizForDashboardList = Quiz & {
+  crosswordQuestions: CrosswordQuestion[];
+  creator: User | null;
+};
+
+export async function listQuizzesForDashboard(): Promise<QuizForDashboardList[]> {
+  const showE2eSeed =
+    process.env.SHOW_E2E_SEED_IN_DASHBOARD_LIST === "1" ||
+    process.env.SHOW_E2E_SEED_IN_DASHBOARD_LIST === "true";
+
+  return prisma.quiz.findMany({
+    where: showE2eSeed ? undefined : whereQuizExcludingE2eSeed,
+    orderBy: { createdAt: "desc" },
+    include: {
+      crosswordQuestions: true,
+      creator: true,
+    },
+  });
+}
 
 export async function getQuizWithCrosswordById(
   quizId: string
@@ -25,6 +53,9 @@ export async function getQuizWithCrosswordByShareLink(
     where: { shareLink },
     include: {
       crosswordQuestions: {
+        orderBy: { order: "asc" },
+      },
+      multipleChoiceQuestions: {
         orderBy: { order: "asc" },
       },
     },

--- a/src/modules/quiz/validation/multiple-choice-questions.ts
+++ b/src/modules/quiz/validation/multiple-choice-questions.ts
@@ -1,0 +1,124 @@
+export const MC_DIFFICULTIES = ["easy", "medium", "hard", "extreme"] as const;
+
+export type McDifficulty = (typeof MC_DIFFICULTIES)[number];
+
+export function isMcDifficulty(value: string): value is McDifficulty {
+  return (MC_DIFFICULTIES as readonly string[]).includes(value);
+}
+
+export type NormalizedMultipleChoiceQuestion = {
+  question: string;
+  options: [string, string, string, string];
+  answer: number;
+  difficulty: McDifficulty;
+  order: number;
+};
+
+function parseOptions(raw: unknown): string[] | null {
+  if (Array.isArray(raw)) {
+    return raw.map((x) => String(x ?? "").trim());
+  }
+  if (typeof raw === "string") {
+    try {
+      const j = JSON.parse(raw) as unknown;
+      if (Array.isArray(j)) {
+        return j.map((x) => String(x ?? "").trim());
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function normalizeMultipleChoiceQuestions(
+  questions: unknown,
+  playLengthRaw: unknown
+): | { ok: true; questions: NormalizedMultipleChoiceQuestion[]; playLength: number }
+  | { ok: false; message: string } {
+  if (!Array.isArray(questions) || questions.length === 0) {
+    return { ok: false, message: "Multiple choice cần ít nhất một câu hỏi." };
+  }
+
+  const pl =
+    typeof playLengthRaw === "number"
+      ? playLengthRaw
+      : typeof playLengthRaw === "string"
+        ? parseInt(playLengthRaw, 10)
+        : NaN;
+  if (!Number.isInteger(pl) || pl < 1) {
+    return {
+      ok: false,
+      message: "Số câu trong một lần chơi (playLength) phải là số nguyên ≥ 1.",
+    };
+  }
+  if (pl > questions.length) {
+    return {
+      ok: false,
+      message: `playLength (${pl}) không được lớn hơn số câu trong ngân hàng (${questions.length}).`,
+    };
+  }
+
+  const out: NormalizedMultipleChoiceQuestion[] = [];
+
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    if (!q || typeof q !== "object") {
+      return { ok: false, message: `Câu ${i + 1}: dữ liệu không hợp lệ.` };
+    }
+    const rec = q as Record<string, unknown>;
+    const question = String(rec.question ?? "").trim();
+    if (!question) {
+      return { ok: false, message: `Câu ${i + 1}: thiếu nội dung câu hỏi.` };
+    }
+
+    const opts = parseOptions(rec.options);
+    if (!opts || opts.length !== 4) {
+      return {
+        ok: false,
+        message: `Câu ${i + 1}: cần đúng 4 phương án (A–D).`,
+      };
+    }
+    if (opts.some((s) => !s)) {
+      return {
+        ok: false,
+        message: `Câu ${i + 1}: mỗi phương án phải có nội dung.`,
+      };
+    }
+
+    const answerRaw = rec.answer ?? rec.correctOption;
+    const answer =
+      typeof answerRaw === "number"
+        ? answerRaw
+        : typeof answerRaw === "string"
+          ? parseInt(answerRaw, 10)
+          : NaN;
+    if (!Number.isInteger(answer) || answer < 0 || answer > 3) {
+      return {
+        ok: false,
+        message: `Câu ${i + 1}: đáp án đúng phải là chỉ số 0–3 (A–D).`,
+      };
+    }
+
+    const diffRaw = String(rec.difficulty ?? "").trim();
+    if (!isMcDifficulty(diffRaw)) {
+      return {
+        ok: false,
+        message: `Câu ${i + 1}: độ khó phải là easy, medium, hard hoặc extreme.`,
+      };
+    }
+
+    out.push({
+      question,
+      options: [opts[0]!, opts[1]!, opts[2]!, opts[3]!],
+      answer,
+      difficulty: diffRaw,
+      order:
+        typeof rec.order === "number" && Number.isInteger(rec.order)
+          ? rec.order
+          : i + 1,
+    });
+  }
+
+  return { ok: true, questions: out, playLength: pl };
+}

--- a/src/modules/quiz/validation/quiz-create-body.ts
+++ b/src/modules/quiz/validation/quiz-create-body.ts
@@ -3,6 +3,10 @@ import {
   normalizeCrosswordQuestions,
   type NormalizedCrosswordQuestion,
 } from "./crossword-questions";
+import {
+  normalizeMultipleChoiceQuestions,
+  type NormalizedMultipleChoiceQuestion,
+} from "./multiple-choice-questions";
 
 export type QuizCreateBody = {
   title: string;
@@ -11,7 +15,9 @@ export type QuizCreateBody = {
   secretWord?: string | null;
   imageUrl?: string | null;
   questions?: unknown;
+  playLength?: number | null;
   normalizedCrosswordQuestions?: NormalizedCrosswordQuestion[];
+  normalizedMcQuestions?: NormalizedMultipleChoiceQuestion[];
 };
 
 export function parseQuizCreateBody(
@@ -34,6 +40,8 @@ export function parseQuizCreateBody(
 
   const type = typeRaw;
 
+  const playLengthRaw = b.playLength;
+
   const data: QuizCreateBody = {
     title,
     type,
@@ -41,7 +49,28 @@ export function parseQuizCreateBody(
     secretWord: typeof b.secretWord === "string" ? b.secretWord : null,
     imageUrl: typeof b.imageUrl === "string" ? b.imageUrl : null,
     questions: b.questions,
+    playLength:
+      typeof playLengthRaw === "number"
+        ? playLengthRaw
+        : typeof playLengthRaw === "string"
+          ? parseInt(playLengthRaw, 10)
+          : null,
   };
+
+  if (type === "multiple_choice") {
+    const norm = normalizeMultipleChoiceQuestions(b.questions, playLengthRaw);
+    if (!norm.ok) {
+      return { ok: false, message: norm.message };
+    }
+    return {
+      ok: true,
+      data: {
+        ...data,
+        playLength: norm.playLength,
+        normalizedMcQuestions: norm.questions,
+      },
+    };
+  }
 
   if (type === "crossword_basic" || type === "crossword_advanced") {
     const norm = normalizeCrosswordQuestions(

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -27,5 +27,6 @@ Mỗi lần **fix bug**, **sửa spec**, hoặc **thêm chức năng** có tài 
 | [task-002-crossword-basic-spec](./task-002-crossword-basic-spec/) | Spec & checklist triển khai crossword basic. |
 | [e2e-full-app-playbook](./e2e-full-app-playbook/) | Kịch bản E2E toàn màn (review trước khi code test). |
 | [task-003-crossword-advanced-spec](./task-003-crossword-advanced-spec/) | Crossword advanced — một ảnh, lưới R×C, mở mảnh theo câu đúng; public/modal như basic. |
+| [task-004-multiple-choice-spec](./task-004-multiple-choice-spec/) | Multiple choice — MVP code + spec v1; E2E `task-004-mc-*.spec.ts`. |
 
 Task mới: copy cấu trúc từ một folder trên hoặc tạo `task-003-...` rồi thêm một dòng vào bảng này **và** cập nhật [STATUS.md](./STATUS.md).

--- a/tasks/STATUS.md
+++ b/tasks/STATUS.md
@@ -8,23 +8,28 @@ File này là **cái nhìn tổng quát** (đã làm / đang làm / còn nợ). 
 
 ## Ý nghĩa cột **Trạng thái**
 
-| Giá trị | Ý nghĩa |
-|---------|---------|
-| **Hoàn thành** | Mục tiêu task đã đạt; chỉ còn bảo trì nhỏ nếu có. |
-| **Gần xong** | Phần chính xong; còn vài mục phụ / tech debt ghi rõ trong task. |
-| **Đang làm** | Đang triển khai tích cực. |
-| **Chưa bắt đầu** | Chỉ có spec/plan hoặc chưa có code. |
-| **Tạm dừng** | Không ưu tiên trong giai đoạn hiện tại. |
+
+| Giá trị          | Ý nghĩa                                                         |
+| ---------------- | --------------------------------------------------------------- |
+| **Hoàn thành**   | Mục tiêu task đã đạt; chỉ còn bảo trì nhỏ nếu có.               |
+| **Gần xong**     | Phần chính xong; còn vài mục phụ / tech debt ghi rõ trong task. |
+| **Đang làm**     | Đang triển khai tích cực.                                       |
+| **Chưa bắt đầu** | Chỉ có spec/plan hoặc chưa có code.                             |
+| **Tạm dừng**     | Không ưu tiên trong giai đoạn hiện tại.                         |
+
 
 ---
 
 ## Bảng task
 
-| ID | Task | Trạng thái | Tóm tắt tiến độ |
-|----|------|------------|-----------------|
-| [001](./task-001-quiz-refactor/) | Quiz refactor (module, API, bỏ Game) | **Gần xong** | Phase 0–5 xong; Phase 6: còn registry đầy đủ & alias `@/modules` tùy chọn. Phase 5: nợ **`getForPlay`** tách payload (ẩn đáp án MC khi public). Chi tiết: [refactor-plan.md](./task-001-quiz-refactor/refactor-plan.md). |
-| [002](./task-002-crossword-basic-spec/) | Crossword basic — spec & triển khai | **Hoàn thành** (MVP code) | Pipeline `normalizeCrosswordQuestions` + gán index; editor/preview/player + `answersMatch`; e2e Playwright tối thiểu + checklist §5.1 trong [spec.md](./task-002-crossword-basic-spec/spec.md); kiểm thử tay A4–A6 còn mở. |
-| [003](./task-003-crossword-advanced-spec/) | Crossword advanced — ảnh + lưới + keyword | **Chưa bắt đầu** | Spec: [spec.md](./task-003-crossword-advanced-spec/spec.md) — một ảnh, lưới **R×C = N** (ước số, gần vuông), số 1…N random, đúng câu mở đúng ô; đoán secret + modal như basic; min 500KB. |
+
+| ID                                         | Task                                                 | Trạng thái                | Tóm tắt tiến độ                                                                                                                                                                                                                                                           |
+| ------------------------------------------ | ---------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [001](./task-001-quiz-refactor/)           | Quiz refactor (module, API, bỏ Game)                 | **Hoàn thành**            | Phase 0–5 xong; Phase 6: còn registry đầy đủ & alias `@/modules` tùy chọn. Phase 5: nợ `**getForPlay`** tách payload (ẩn đáp án MC khi public). Chi tiết: [refactor-plan.md](./task-001-quiz-refactor/refactor-plan.md).                                                  |
+| [002](./task-002-crossword-basic-spec/)    | Crossword basic — spec & triển khai                  | **Hoàn thành** (MVP code) | Pipeline `normalizeCrosswordQuestions` + gán index; editor/preview/player + `answersMatch`; e2e Playwright tối thiểu + checklist §5.1 trong [spec.md](./task-002-crossword-basic-spec/spec.md); kiểm thử tay A4–A6 còn mở.                                                |
+| [003](./task-003-crossword-advanced-spec/) | Crossword advanced — ảnh + lưới + keyword            | **Hoàn thành**            | Spec: [spec.md](./task-003-crossword-advanced-spec/spec.md) — một ảnh, lưới **R×C = N** (ước số, gần vuông), số 1…N random, đúng câu mở đúng ô; đoán secret + modal như basic; min 500KB.                                                                                 |
+| [004](./task-004-multiple-choice-spec/)    | Multiple choice — bank + play length + bucket random | **Hoàn thành** (MVP code) | Spec [spec.md](./task-004-multiple-choice-spec/spec.md); code: `playLength` + `difficulty`/`order`, `multiple-choice-session`, form/API, `MultipleChoicePlayer`, E2E `task-004-mc-*.spec.ts`.                                                                             |
+
 
 ---
 
@@ -32,8 +37,8 @@ File này là **cái nhìn tổng quát** (đã làm / đang làm / còn nợ). 
 
 Các mục chưa gom vào folder riêng nhưng liên quan trực tiếp bảng trên:
 
-- **Public play + MC:** payload `getForPlay` không lộ đáp án (task 001 / Phase 5).
+- **Public play + MC:** task 004 dùng `GET/POST .../multiple-choice-session` (không lộ đáp án trong GET). Nợ task 001: gom/tách `getForPlay` nếu muốn một entry API duy nhất.
 
 ---
 
-_Cập nhật lần cuối: 2026-04-15 — thêm task 003 (advanced image grid spec)._
+*Cập nhật lần cuối: 2026-04-17 — task 004 MVP + verify.*

--- a/tasks/task-004-multiple-choice-spec/README.md
+++ b/tasks/task-004-multiple-choice-spec/README.md
@@ -1,0 +1,8 @@
+# Task 004 — Multiple choice (spec)
+
+Màn **trắc nghiệm 4 đáp án** với **ngân hàng câu + độ khó**, **`playLength`**, luật **sai 1 câu = game over**, **shuffle** hiển thị, feedback **chọn → khóa → cam → ~5s → xanh nhạt** (trùng đúng: cam + xanh nhấp nháy).
+
+Spec **v1 chốt**: **[spec.md](./spec.md)**.  
+Kế hoạch triển khai (theo phase, có input/output + E2E mỗi phase): **[implementation-plan.md](./implementation-plan.md)**.  
+Báo cáo E2E: **[e2e-test-report.md](./e2e-test-report.md)**.  
+Nhật ký bug: **[fix-bug.md](./fix-bug.md)**.

--- a/tasks/task-004-multiple-choice-spec/e2e-test-report.md
+++ b/tasks/task-004-multiple-choice-spec/e2e-test-report.md
@@ -1,0 +1,116 @@
+# Task 004 — E2E test report (multiple choice)
+
+> **Phạm vi:** chỉ **task 004** — multiple choice (ngân hàng câu, `playLength`, bucket + session deterministic, admin form, public play: khóa → chờ reveal → đúng/sai, game over / thắng).  
+> **Tham chiếu:** [spec.md](./spec.md) · [implementation-plan.md](./implementation-plan.md) · **Bug log:** [fix-bug.md](./fix-bug.md) · Code E2E: `e2e/task-004-mc-*.spec.ts` · Seed: `e2e/constants.ts` (`E2E_SHARE_MC`) + `e2e/global-setup.ts`.  
+> **Share link seed:** `e2e-share-mc` — client + API test dùng query `?sessionSeed=playwright-session` khi `shareLink` bắt đầu bằng `e2e-` (đồng bộ với `MultipleChoicePlayer`).
+
+**Quy ước:** hai lớp mô tả — **nghiệp vụ / logic** (gắn § spec) và **chuỗi thao tác UI hoặc API** — cùng cấu trúc báo cáo E2E task 003 ([e2e-test-report.md](../task-003-crossword-advanced-spec/e2e-test-report.md)). Mọi bug đã sửa ghi [fix-bug.md](./fix-bug.md) và ánh xạ vào **§1.3** + bảng **§4** (rule: `quiz-delivery-and-docs.mdc` mục 10, `quiz-e2e-and-test-docs.mdc`).
+
+**Cập nhật lần cuối:** 2026-04-17 — `npm run verify` pass; animation `mc-blink-green` / `mc-blink-green-amber`, thắng có `mc-play-again`, đồng bộ [fix-bug.md](./fix-bug.md) **BUG-004-04**.
+
+---
+
+## 1. Tiền đề & công cụ
+
+| Hạng mục | Giá trị / ghi chú |
+|----------|-------------------|
+| **Runner** | Playwright (`@playwright/test`), `playwright.config.ts`. |
+| **Chạy** | `npm run e2e` hoặc `npm run verify` (script có `build` trước `next start` trên port **3005**). |
+| **Admin** | `loginAsAdmin` — `e2e/helpers/auth.ts` (`admin@example.com`). |
+| **Session deterministic** | `GET .../multiple-choice-session?sessionSeed=playwright-session` chỉ khi quiz có `shareLink` prefix `e2e-`; `POST` dùng `sessionSeed` trả từ GET. |
+
+### 1.1 Hai lớp trong tài liệu
+
+| Lớp | Mục đích |
+|-----|----------|
+| **Nghiệp vụ / logic** | Gắn mã với [spec.md](./spec.md) — **§2** bên dưới. |
+| **Thao tác UI / API** | Chuỗi bước cụ thể — **§1.2** (play) + **§1.2b** (admin). |
+
+### 1.2 Chuỗi thao tác UI / API — play public (`/play/e2e-share-mc`)
+
+| Mã | Route / API | Chuỗi thao tác & assert chính |
+|----|-------------|------------------------------|
+| **T004-play-01** | `GET /api/play/e2e-share-mc/multiple-choice-session?sessionSeed=playwright-session` | `APIRequestContext.get` → JSON **không** có key `answer` / `correctIndex` / `correctOption`; `questions[0]` không có `answer`; `questions.length === playLength` (1). |
+| **T004-play-02** | `GET` + `POST` (brute `selectedIndex` 0…3) + `/play/e2e-share-mc` | Tìm index thắng qua API → `page.goto` → click `data-testid=mc-option-{i}` → **không** có banner copy chờ; trong ~12s thấy `mc-win` (**spec §3.3** thắng câu cuối) → click **`mc-play-again`** → `mc-question-text` hiện lại ([fix-bug BUG-004-04](./fix-bug.md)). |
+| **T004-play-03** | idem + UI | Click **sai** `mc-option-{wrong}` → chờ ~5s im lặng (ô đã chọn **cam**) → xuất hiện **một** nút `[data-mc-correct-reveal="true"]` (đáp án đúng) + class **`mc-blink-green`** (**spec §3.2** + [fix-bug BUG-004-01](./fix-bug.md) / [BUG-004-04](./fix-bug.md)) → `mc-game-over` + `mc-play-again` → click → `mc-question-text` hiện lại (phiên mới). |
+
+### 1.3 Hồi quy bug ([fix-bug.md](./fix-bug.md))
+
+| Mã bug | Kỳ vọng (nghiệp vụ) | Test Playwright / assert |
+|--------|---------------------|----------------------------|
+| **BUG-004-01** | Sai vẫn thấy ô đúng xanh + nhấp nháy trước banner thua | **T004-play-03:** `data-mc-correct-reveal` + **`mc-blink-green`** trước `mc-game-over`. |
+| **BUG-004-02** | Thêm câu MC không phải scroll lên đầu trang | Thủ công / UI — nút `mc-add-question-after-card` cuối mỗi card. |
+| **BUG-004-03** | Không hiện copy 「Đáp án sẽ được công bố sau…」 | **T004-play-02/03:** không assert `mc-suspense` (đã gỡ). |
+| **BUG-004-04** | Đúng: xanh/cam nhấp nháy; sai: xanh nhấp nháy mạnh; thắng: có **Chơi lại** + delay trước khi ẩn lưới | **T004-play-02:** `mc-win` → `mc-play-again` → câu hỏi. **T004-play-03:** class `mc-blink-green` trên ô đúng. |
+
+### 1.2b Chuỗi thao tác UI — admin (`/quizzes/create`)
+
+| Mã | Route | Chuỗi thao tác chính |
+|----|--------|----------------------|
+| **T004-admin-01** | `/quizzes/create` | `loginAsAdmin` → `#type` = multiple choice (mặc định) → `#title` = `E2E T004 MC create` → `#playLength` = 1 → điền **một** câu: nội dung + 4 ô A–D + chọn đáp án đúng (radio) → **Tạo Quiz** → URL `/quizzes` → `getByRole('heading', { name: '...' }).first()` visible (tránh strict mode khi trùng tiêu đề nhiều thẻ). |
+
+---
+
+## 2. E2E scenarios vs spec
+
+Cột **Trạng thái:** **Pass** = đã có trong `e2e/task-004-*.spec.ts`.
+
+### §1 Admin — ngân hàng & `playLength`
+
+| Mã | Scenario (tóm tắt) | Trạng thái |
+|----|-------------------|------------|
+| **T004-§1** | ≥1 câu, 4 option, độ khó, `playLength` ≤ số câu; lưu DB | **Pass** — **T004-admin-01** (happy path tối thiểu) |
+
+### §2 Bucket & session (logic server)
+
+| Mã | Scenario | Trạng thái |
+|----|----------|------------|
+| **T004-§2** | `buildMultipleChoiceSession` deterministic theo `seedKey`; GET không lộ đáp án | **Pass** — **T004-play-01** + Vitest `multiple-choice-session.test.ts` |
+
+### §3 Màn chơi — reveal, màu, game over / thắng
+
+| Mã | Scenario | Trạng thái |
+|----|----------|------------|
+| **§3.2** | Chọn → khóa → ~5s → công bố đúng (xanh/cam nhấp nháy nếu đúng; xanh nhấp nháy ô đúng nếu sai) | **Pass** — **T004-play-02** / **T004-play-03** ([BUG-004-04](./fix-bug.md)) |
+| **§3.3** | Sai → game over + Chơi lại reset phiên; thắng → **Chơi lại** | **Pass** — **T004-play-02** / **T004-play-03** |
+
+---
+
+## 3. Bảng tổng hợp file test
+
+| File | Nội dung | Trạng thái |
+|------|----------|------------|
+| `e2e/task-004-mc-play.spec.ts` | **T004-play-01**–**03** (API + UI thắng/thua + reveal đúng) | Pass |
+| `e2e/task-004-mc-admin.spec.ts` | **T004-admin-01** | Pass |
+
+---
+
+## 4. Bảng tổng hợp trạng thái (theo dõi)
+
+| Mã | Trạng thái | Ghi chú |
+|----|------------|---------|
+| **T004-play-01** | Pass | Không lộ đáp án GET |
+| **T004-play-02** | Pass | Thắng + `mc-win` + **Chơi lại** → phiên mới (**BUG-004-04**) |
+| **T004-play-03** | Pass | Sai → `data-mc-correct-reveal` + **`mc-blink-green`** → `mc-game-over` → Chơi lại (**BUG-004-01**, **BUG-004-04**) |
+| **T004-admin-01** | Pass | Tạo MC tối thiểu |
+| **BUG-004-02** | Pass | UI admin — `fix-bug.md` |
+| **BUG-004-03** | Pass | Gỡ `mc-suspense` — `fix-bug.md` |
+| **BUG-004-04** | Pass | Nhấp nháy CSS + Chơi lại khi thắng — `fix-bug.md` |
+
+---
+
+## 5. Lộ trình mở rộng Playwright
+
+| Đợt | Việc làm |
+|-----|----------|
+| **1** | `playLength > 1`: assert tiến câu sau khi đúng (round 2…) + thắng ở câu cuối. |
+| **2** | Admin: sửa quiz MC có sẵn (`/quizzes/[id]/edit`) — assert field `playLength` + reorder. |
+| **3** | Visual / a11y: assert nhãn `sr-only` hoặc `aria-live` sau chỉnh copy. |
+
+---
+
+## 6. Sau khi sửa code MC / bug
+
+- **Bắt buộc:** thêm mục vào [fix-bug.md](./fix-bug.md) (rule `quiz-delivery-and-docs.mdc` mục 10).  
+- Cập nhật `e2e/task-004-*.spec.ts`, bảng **§1.2 / §1.2b / §1.3**, **§2**, **§4** (rule: `quiz-e2e-and-test-docs.mdc`).  
+- Cập nhật [spec.md](./spec.md) nếu đổi hành vi nghiệp vụ.

--- a/tasks/task-004-multiple-choice-spec/fix-bug.md
+++ b/tasks/task-004-multiple-choice-spec/fix-bug.md
@@ -1,0 +1,90 @@
+# Bug log — multiple choice (task 004)
+
+**Quy ước:** Mọi bug / chỉnh hành vi đáng kể trong phạm vi task 004 (MC admin, session API, `MultipleChoicePlayer`, E2E) ghi **một mục mới** (theo thời gian hoặc `[BUG-xxx]`) dưới đây. Khi code xong: **Trạng thái** = đã fix + **Đã test** + đồng bộ [e2e-test-report.md](./e2e-test-report.md) (§1.2 / §4).
+
+---
+
+## 2026-04-17 — [BUG-004-01] Sai đáp án: không thấy ô đúng (xanh nhấp nháy)
+
+### Triệu chứng
+
+- Sau khi chọn **sai**, màn hình chuyển **game over** ngay mà **không** còn lưới 4 phương án, nên **không** thấy đáp án đúng với nền **xanh nhạt** và **nhấp nháy** như [spec.md](./spec.md) §3.2–§3.3.
+
+### Nguyên nhân gốc
+
+- `setGameOver(true)` được gọi **cùng lúc** với reveal nhưng điều kiện render lưới là `!gameOver` → toàn bộ khối câu hỏi + option **unmount** trước khi user kịp thấy highlight đúng.
+
+### Cách sửa (đã áp dụng)
+
+- Sau `setRevealed` + gán `correctDisplayIndex`, **chờ thêm ~2,8s** rồi mới `setGameOver(true)`.
+- Điều kiện hiển thị lưới: vẫn hiện khi `gameOver && revealed` (xem `MultipleChoicePlayer` — `showOptionsBlock`).
+- Ô đúng: `data-mc-correct-reveal="true"` + nhấp nháy (sau này **BUG-004-04** dùng `mc-blink-green` thay `animate-pulse`); banner **「Bạn đã thua」** đặt **dưới** lưới.
+
+### Kiểm thử hồi quy
+
+- **Đã test:** `npm run verify` — Playwright **T004-play-03** assert `data-mc-correct-reveal` + class **`mc-blink-green`** trước `mc-game-over` (đồng bộ **BUG-004-04**).
+
+**Trạng thái:** **Đã fix**.
+
+---
+
+## 2026-04-17 — [BUG-004-04] MC play: làm nổi bật đáp án đúng + thiếu 「Chơi lại」khi thắng
+
+### Triệu chứng
+
+1. **Trả lời đúng:** cần **xanh + cam** xen kẽ rõ rệt (nhấp nháy liên tục) để nổi bật ô đúng — `animate-pulse` một màu chưa đủ.
+2. **Trả lời sai:** ô đáp án đúng (xanh) cần **nhấp nháy liên tục** thay vì pulse nhẹ.
+3. **Thắng:** chỉ có banner **「Bạn là người chiến thắng」**, **không** có nút **Chơi lại** — user không biết cách chơi lại.
+
+### Nguyên nhân gốc
+
+- Chỉ dùng utility Tailwind `animate-pulse` (opacity) trên một nền cố định → tương phản yếu.
+- `showOptionsBlock` phụ thuộc `!won`: gọi `setWon(true)` **ngay** sau `setRevealed(true)` → lưới option **biến mất tức thì**, không thời gian xem highlight thắng; UI thắng không có CTA reset phiên.
+
+### Cách sửa (đã áp dụng)
+
+- Thêm keyframes trong `src/app/globals.css`: **`mc-blink-green-amber`** (ô vừa chọn vừa đúng sau reveal), **`mc-blink-green`** (ô đúng khi user chọn sai).
+- `MultipleChoicePlayer`: gắn class tương ứng thay cho `animate-pulse` trên ô có `data-mc-correct-reveal`.
+- Khi **thắng** (`revealPayload.won`): **`await` ~1,8s** rồi mới `setWon(true)` để vẫn thấy lưới + nhấp nháy; trong banner thắng thêm nút **`Chơi lại`** (`data-testid="mc-play-again"`, cùng id với màn thua).
+
+### Kiểm thử hồi quy
+
+- **Đã test:** `npm run verify` — **T004-play-03:** `mc-blink-green` trên ô đúng; **T004-play-02:** sau `mc-win` click `mc-play-again` → `mc-question-text` hiện lại.
+
+**Trạng thái:** **Đã fix**.
+
+---
+
+## 2026-04-17 — [BUG-004-02] Admin MC: nút 「+ Thêm câu hỏi」chỉ ở đầu danh sách
+
+### Triệu chứng
+
+- Nút **+ Thêm câu hỏi** nằm cố định **trên** cùng; khi đã kéo xuống nhập câu cuối, muốn thêm câu phải **scroll lên** — khó thao tác.
+
+### Cách sửa (đã áp dụng)
+
+- Bỏ nút cạnh tiêu đề **Ngân hàng câu hỏi**; thêm nút **+ Thêm câu hỏi** ở **cuối mỗi card** câu (`data-testid="mc-add-question-after-card"`).
+
+### Kiểm thử hồi quy
+
+- **Đã test:** `npm run verify` (E2E admin T004 không phụ thuộc nút mới; hành vi thủ công).
+
+**Trạng thái:** **Đã fix**.
+
+---
+
+## 2026-04-17 — [BUG-004-03] Copy 「Đáp án sẽ được công bố sau…」không tự nhiên
+
+### Triệu chứng
+
+- Sau khi chọn đáp án, hiện dòng chữ kiểu **「Đáp án sẽ được công bố sau…」** — product cảm thấy **không tự nhiên**, không cần thiết.
+
+### Cách sửa (đã áp dụng)
+
+- **Gỡ** hoàn toàn block copy chờ (`mc-suspense`) khỏi `MultipleChoicePlayer`; giữ **khóa + cam** rồi **chờ ~5s** im lặng rồi reveal (đúng spec thời gian, không bắt buộc chữ).
+
+### Kiểm thử hồi quy
+
+- **Đã test:** `npm run verify` — cập nhật **T004-play-02** / **T004-play-03** (bỏ assert `mc-suspense`).
+
+**Trạng thái:** **Đã fix**.

--- a/tasks/task-004-multiple-choice-spec/implementation-plan.md
+++ b/tasks/task-004-multiple-choice-spec/implementation-plan.md
@@ -1,0 +1,111 @@
+# Task 004 — Kế hoạch triển khai Multiple choice (MCQ)
+
+> **Mục đích:** triển khai [spec.md](./spec.md) v1 — model, admin, API public (không lộ đáp án trước reveal), màn chơi + E2E.  
+> **Phạm vi:** plan + **code đã triển khai** (2026-04-17).  
+> **Tham chiếu code:** `prisma/schema.prisma` (`Quiz`, `MultipleChoiceQuestion`), `parseQuizCreateBody`, `src/app/play/[shareLink]/page.tsx` (hiện MC chưa có player), E2E Playwright hiện có (`e2e/task-002-*.spec.ts`, …).  
+> **Ngày lập:** 2026-04-17.
+
+---
+
+## 0. Nguyên tắc chung
+
+1. **Cuối mỗi phase** (bắt buộc): chạy **`npm run e2e`** — toàn bộ suite Playwright **xanh** trước khi merge phase đó. Ghi rõ trong PR/commit phase. (Tuỳ chọn thêm: `npm run test:unit` nếu phase có Vitest.)
+2. **Phiên bản E2E mới** đặt tên theo quy ước repo, ví dụ: `e2e/task-004-mc-admin.spec.ts`, `e2e/task-004-mc-play.spec.ts` — cập nhật [e2e-test-report.md](./e2e-test-report.md) (tạo khi phase có case mới) theo [.cursor/rules/quiz-e2e-and-test-docs.mdc](../../.cursor/rules/quiz-e2e-and-test-docs.mdc).
+3. **Public không lộ đáp án đúng** trước khi user đã khóa lựa chọn và server trả “reveal” (đáp ứng backlog `getForPlay` / task 001): payload JSON cho client **không** chứa index/slot đúng; shuffle **có thể làm trên server** rồi trả mảng `options[]` đã xáo (client không cần biết đáp án để render ô).
+
+---
+
+## Phase 1 — Schema & migration
+
+| | Nội dung |
+|---|----------|
+| **Input** | [spec.md](./spec.md) §1 (ngân hàng, `playLength`, 4 option, slot đúng, độ khó); `schema.prisma` hiện tại (`MultipleChoiceQuestion`: `question`, `options` JSON, `answer` Int). |
+| **Output** | Migration Prisma đã apply: ví dụ **`Quiz.playLength`** (`Int`, nullable — bắt buộc có giá trị hợp lệ khi `type === 'multiple_choice'`), **`MultipleChoiceQuestion.difficulty`** (`String` hoặc enum Prisma: `easy` \| `medium` \| `hard` \| `extreme` — map UI tiếng Việt ở tầng app), tuỳ chọn **`order`** (`Int`) cho thứ tự hiển thị trong admin (không quyết định thứ tự chơi public). Seed/migration dữ liệu dev (nếu có) không phá E2E cũ. `prisma generate` OK. |
+| **E2E** | `npm run e2e` — **không** thêm case mới; regression toàn repo. |
+
+**Ghi chú kỹ thuật:** `answer` Int **0–3** = slot A–D đúng trong mảng `options` **trước** shuffle; logic shuffle chỉ áp dụng cho payload public và map ngược khi chấm.
+
+---
+
+## Phase 2 — Domain logic thuần (bucket + pick câu)
+
+| | Nội dung |
+|---|----------|
+| **Input** | Spec §2 (`L`, tỉ lệ 4:4:4:1, Hamilton, `L ≥ 13` / `L < 13`), §2.3 (ưu tiên không trùng `questionId`, cho phép trùng khi buộc). |
+| **Output** | Module ví dụ `src/modules/quiz/lib/multiple-choice-session.ts` (tên file có thể chốt lúc code) export: `computeBucketCounts(L)`, `bucketForPosition(i, counts)`, `pickQuestionsForSession(bank, L, rng)` (hoặc tách nhỏ). **Vitest** (tuỳ chọn nhưng khuyến nghị): bảng kỳ vọng `L = 1…12`, `L = 13`, `L = 20`; case pool 1 câu/bucket → có trùng. |
+| **E2E** | `npm run e2e` — regression; phase này **chưa** bắt buộc file E2E mới nếu chưa đụng UI (chỉ lib + unit). |
+
+---
+
+## Phase 3 — Admin: validate + API + form MC
+
+| | Nội dung |
+|---|----------|
+| **Input** | Schema phase 1; `parseQuizCreateBody` / handler `POST`/`PUT` quiz; `QuizForm.tsx`; pattern crossword validation. |
+| **Output** | Nhánh `multiple_choice` trong parse/normalize: **đúng 4** option text; **`playLength`** nguyên dương, **`playLength` ≤ số câu**; mỗi câu có **`difficulty`** hợp lệ; **`answer` ∈ [0,3]**; lưu DB đúng. Form admin: thêm/sửa câu (prompt, 4 ô A–D, chọn đúng một, chọn độ khó), field **`playLength`**. API create/update quiz type MC không 500. |
+| **E2E** | `npm run e2e` — trong đó **file mới** `e2e/task-004-mc-admin.spec.ts`: luồng tối thiểu (đăng nhập admin nếu playbook yêu cầu → tạo quiz MC với N câu + `playLength` → submit thành công / hoặc assert DB qua UI list). |
+
+---
+
+## Phase 4 — API public: session chơi + không lộ đáp án
+
+| | Nội dung |
+|---|----------|
+| **Input** | Module phase 2; quiz `shareLink`; rule ẩn đáp án (§0 plan). |
+| **Output** | Route handler ví dụ **`GET /api/play/[shareLink]/multiple-choice-session`** (tên cuối có thể rút gọn): load quiz + bank MC; sinh **thứ tự câu trong phiên** + pick theo bucket; với **mỗi câu** trả `{ questionText, options: string[] }` với **`options` đã shuffle** (server dùng RNG seeded hoặc `crypto.randomUUID` + Fisher–Yates — chốt khi code; E2E có thể **mock** hoặc dùng **seed cố định** chỉ `NODE_ENV=test` nếu cần). **Không** trả `answer` / `correctIndex`. **POST** (hoặc Server Action) ví dụ **`POST .../multiple-choice-answer`**: body `{ roundIndex, selectedIndex }` → response `{ correctDisplayIndex, isCorrect, gameOver, won }` để client làm reveal sau 5s (client có thể gọi POST ngay khi chọn rồi **trì hoãn hiển thị** kết quả tới hết timer — tránh hiển thị sớm; hoặc POST sau 5s — **chốt UX khi code**, miễn không gửi đáp án đúng trong GET ban đầu). |
+| **E2E** | `npm run e2e` — thêm case trong `task-004-mc-play.spec.ts` (có thể bắt đầu file ở phase này): **`request.get`** session → assert JSON **không** có field kiểu `answer` / `correct` / `correctIndex`; assert length `questions === playLength` (hoặc tương đương). Có thể dùng quiz seed từ phase 3 hoặc `global-setup`. |
+
+---
+
+## Phase 5 — UI màn chơi `/play/[shareLink]`
+
+| | Nội dung |
+|---|----------|
+| **Input** | API phase 4; [spec.md](./spec.md) §3 (shuffle đã ở payload, khóa sau chọn, cam / xanh nhạt / blink, ~5s có thể im lặng không bắt buộc copy chờ, game over + Chơi lại, thắng câu cuối). |
+| **Output** | `quizTypeSupports*` / registry mở rộng; `page.tsx` render **`MultipleChoicePlayer`** (hoặc tên tương đương) khi `type === 'multiple_choice'`; component: fetch session → hiển thị từng câu → chọn → khóa → chờ ~5s (có thể không hiện chữ) → apply style reveal; sai → overlay **「Bạn đã thua」** + **「Chơi lại」** (fetch session mới); đúng hết → **「Bạn là người chiến thắng」**; a11y: không chỉ màu. |
+| **E2E** | `npm run e2e` — mở rộng `e2e/task-004-mc-play.spec.ts`: **sai** ở câu 1 → thấy thua + Chơi lại → session mới (có thể assert đổi prompt nếu seed khác hoặc assert số câu reset về 1); **thắng** stub ngắn (`playLength = 1` + một câu dễ, luôn chọn đúng qua UI hoặc intercept) → thông báo chiến thắng. Dùng `data-testid` ổn định theo rule E2E repo. |
+
+---
+
+## Phase 6 — Đồng bộ tài liệu & verify tổng
+
+| | Nội dung |
+|---|----------|
+| **Input** | Code đã xong phase 1–5. |
+| **Output** | Cập nhật `.cursor/rules/quiz-product-architecture.mdc` và `quiz-data-and-api.mdc` (MCQ: bank + `playLength`, không còn mô tả “15 câu cố định” nếu đã lỗi thời). [e2e-test-report.md](./e2e-test-report.md): mã case + kỳ vọng + chuỗi thao tác UI. [../STATUS.md](../STATUS.md): task 004 → **Gần xong** / **Hoàn thành** tùy nợ. |
+| **E2E** | `npm run verify` (hoặc tối thiểu `npm run e2e` + `npm run lint` + `npm run build` theo thói quen repo). |
+
+---
+
+## Rủi ro & phụ thuộc
+
+| Rủi ro | Giảm thiểu |
+|--------|-------------|
+| RNG không deterministic làm E2E flake | Seed từ env test / query chỉ test / `page.route` mock API. |
+| Leak đáp án qua RSC props | Không truyền `correct` vào client component; chỉ truyền sau POST hoặc dùng action trả từng bước. |
+| Phase 4–5 tách GET/POST phức tạp | Có thể gộp MVP: Phase 4 ship GET + POST tối thiểu; Phase 5 chỉ UI. |
+
+---
+
+## 7. Trạng thái làm theo phase (theo dõi khi code)
+
+**Quy ước cột *Trạng thái*:** `Chưa làm` → `Đang làm` → `Xong`.  
+**Khi xong một phase:** đổi trạng thái, ghi **ngày** (hoặc hash commit / PR), và xác nhận đã chạy **`npm run e2e`** (hoặc `npm run verify` nếu phase 6).
+
+| Phase | Trạng thái | Ngày / tham chiếu | `npm run e2e` (hoặc verify) |
+|-------|------------|-------------------|------------------------------|
+| 1 — Schema & migration | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+| 2 — Domain logic thuần | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+| 3 — Admin validate + form + API | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+| 4 — API public session + ẩn đáp án | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+| 5 — UI màn chơi | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+| 6 — Docs + verify tổng | **Xong** | 2026-04-17 | `npm run verify` (pass) |
+
+**Ghi chú nhanh (tuỳ chọn, cập nhật khi làm):**
+
+- Bucket trống: `pickQuestionForBucket` fallback toàn ngân hàng (không validate đủ pool theo spec).
+- E2E MC: `shareLink` prefix `e2e-` + query `sessionSeed=playwright-session` (và client `MultipleChoicePlayer` gửi cùng seed) để phiên deterministic; seed quiz `e2e-share-mc` trong `global-setup.ts`.
+
+---
+
+_Cập nhật: 2026-04-17 — triển khai code + cập nhật §7; rule `quiz-delivery-and-docs.mdc` bổ sung hướng dẫn cập nhật §7 khi làm theo phase._

--- a/tasks/task-004-multiple-choice-spec/spec.md
+++ b/tasks/task-004-multiple-choice-spec/spec.md
@@ -1,0 +1,97 @@
+# Multiple choice — functional spec (v1 chốt)
+
+> Trạng thái: **spec v1 đã chốt** (2026-04-17) — sẵn sàng làm backlog implement / e2e.  
+> Rule tổng quan: [.cursor/rules/quiz-product-architecture.mdc](../../.cursor/rules/quiz-product-architecture.mdc). Phần MCQ **15 câu cố định theo thứ tự** trong file đó **bị thay thế** bởi spec này cho loại `multiple_choice`.
+
+---
+
+## 1. Admin — ngân hàng câu hỏi
+
+- Admin tạo **nhiều câu hỏi** cho một quiz loại multiple choice.
+- Mỗi câu có **đúng 4 phương án** (slot **A, B, C, D** trong dữ liệu — admin nhập nội dung từng slot).
+- Admin **chỉ định rõ slot nào là đáp án đúng** (một trong A / B / C / D). Đây là nguồn sự thật khi chấm đúng/sai; **không** suy từ thứ tự hiển thị sau khi shuffle (mục §3).
+- Mỗi câu có **một** mức độ khó: **dễ** | **trung bình** | **khó** | **siêu khó**.
+- Admin chỉ định `**playLength`** = số câu trong **một lần chơi**. Bắt buộc: `**playLength` ≤ tổng số câu** trong ngân hàng của bài đó.
+- **Không** bắt buộc validate thêm theo “đủ pool từng bucket” hay “mỗi mức ít nhất N câu” — thiếu câu trong bucket vẫn cho phép lưu và chơi; engine xử lý theo §2.3.
+
+---
+
+## 2. Phân bucket theo vị trí câu trong phiên
+
+### 2.1 Mẫu chuẩn (tham chiếu `L_ref = 13`)
+
+Ranh giới **không chồng** — áp dụng khi `playLength ≥ 13` cho các vị trí 1…13:
+
+
+| Vị trí câu trong phiên | Bucket độ khó |
+| ---------------------- | ------------- |
+| **1 – 4**              | Dễ            |
+| **5 – 8**              | Trung bình    |
+| **9 – 12**             | Khó           |
+| **13+**                | Siêu khó      |
+
+
+Với `playLength = 13`: đúng **4 + 4 + 4 + 1** câu theo bốn mức (câu 13 chỉ thuộc siêu khó).
+
+### 2.2 `playLength = L` — co giảm theo tỉ lệ & mở rộng dài phiên
+
+**Trường hợp `L ≥ 13`:** giữ đúng ranh giới mục §2.1 cho các vị trí **1…12**; mọi vị trí **13 … `L`** đều thuộc bucket **siêu khó** (ví dụ `L = 20` → 4 dễ + 4 TB + 4 khó + 8 siêu khó).
+
+**Trường hợp `L < 13`:** co giảm theo **cùng tỉ lệ** 4 : 4 : 4 : 1 trên 13 câu:
+
+- Tính bốn số nguyên `**n_E`, `n_M`, `n_H`, `n_S`** sao cho `n_E + n_M + n_H + n_S = L` và gần với tỉ lệ trên (chuẩn kỹ thuật: **largest remainder / Hamilton** trên `L × (4,4,4,1) / 13`, phần dư phân cho các bucket có phần thập phân lớn nhất; **tie-break** cố định **dễ → trung bình → khó → siêu khó**).
+- Gán bucket theo **thứ tự vị trí câu** (độ khó tăng dần theo index):
+  - Câu **1 … `n_E`**: **dễ**;
+  - tiếp `**n_M`** câu: **trung bình**;
+  - tiếp `**n_H`** câu: **khó**;
+  - `**n_S`** câu cuối: **siêu khó**.
+
+*Ví dụ `L = 8`: **3 dễ + 2 TB + 2 khó + 1 SK** (Hamilton); QA có thể bảng hóa `L = 1…12` để đối chiếu.*
+
+`**L ≥ 1`:** không cho phép `playLength = 0` (một lần chơi phải có ít nhất một câu).
+
+### 2.3 Chọn câu ngẫu nhiên trong bucket
+
+- Với mỗi vị trí câu, **random** một câu trong ngân hàng **thuộc đúng bucket** độ khó của vị trí đó.
+- **Ưu tiên không trùng** cùng một câu (cùng `questionId` / row) trong **một phiên**: khi còn đủ câu khác trong bucket (và chưa dùng hết trong phiên), **không** chọn lại câu đã dùng.
+- **Ngoại lệ:** nếu admin **chỉ có một câu** (hoặc tập đã dùng hết) cho bucket / tình huống đó thì **cho phép trùng** cùng một câu trong phiên — không báo lỗi.
+- **Không** validate bắt buộc “đủ pool” lúc lưu hay lúc bắt đầu chơi; không bắt buộc fallback sang bucket khác — chỉ random trong đúng bucket của vị trí, kèm quy tắc trùng như trên.
+
+---
+
+## 3. Màn chơi user — đáp án & hiển thị
+
+### 3.1 Shuffle thứ tự 4 phương án
+
+- Khi render màn chơi: **xáo trộn thứ tự hiển thị** bốn phương án (seed theo phiên hoặc theo câu — chi tiết implement).
+- Đáp án đúng vẫn xác định bởi **slot admin đã chọn** (mục §1); UI map index shuffle ↔ id slot để chấm đúng/sai.
+
+### 3.2 Chọn đáp án, khóa, chờ 5s, reveal
+
+- User chọn **một** phương án:
+  - Ngay sau khi chọn: **khóa** — **không** cho đổi lựa chọn (kể cả trong ~5s chờ và sau khi reveal).
+  - Phương án được chọn: style **cam** (selected).
+  - **Không** bắt buộc hiển thị dòng copy chờ giữa lúc khóa và reveal (tránh cảm giác không tự nhiên); có thể chỉ **im lặng** trong ~5s rồi công bố đáp án đúng.
+- Sau **khoảng 5 giây** (có thể ±tolerance nhỏ do timer; không yêu cầu frame-perfect):
+  - Phương án **đúng**: style **xanh nhạt** (correct), nhấp nháy.
+  - Nếu user chọn **trùng** đáp án đúng: **cam + xanh nhạt chồng** và **nhấp nháy** (blink) theo đã thống nhất.
+
+### 3.3 Sai / thắng / chơi lại
+
+- **Sai** ở bất kỳ câu nào → **game over**; hiển thị màn / modal có copy **「Bạn đã thua」** (hoặc tương đương) và nút **「Chơi lại」** — bấm thì **bắt đầu phiên mới từ câu 1** (generate lại thứ tự câu / shuffle đáp án theo rule, không reset im lặng).
+- **Câu cuối** của phiên: nếu **đúng** → thông điệp **「Bạn là người chiến thắng」** (copy có thể tinh chỉnh sau).
+
+### 3.4 Accessibility
+
+- Trạng thái đúng/sai/chọn không chỉ dựa vào màu: nên kèm **viền / icon / nhãn text** (implement).
+
+---
+
+## 4. Liên hệ codebase & API (nhắc việc)
+
+- Validate body admin: pattern `src/modules/quiz/validation/…`.
+- Public play: payload **không** lộ đáp án đúng trước reveal — backlog [tasks/STATUS.md](../STATUS.md) (`getForPlay` / task 001).
+
+---
+
+*Cập nhật: 2026-04-17 — v1 chốt theo xác nhận product.*


### PR DESCRIPTION
- Add MC session API, MultipleChoicePlayer, validation, migration, and specs.
- Split Playwright DB (e2e.db), DATABASE_URL in scripts, global-setup migrate.
- Hide E2E seed quizzes on admin dashboard unless SHOW_E2E_SEED_IN_DASHBOARD_LIST.
- MC UX: green/amber and green blink animations, Play again on win, docs in fix-bug/e2e-test-report.
- Exclude prisma/dev.db from commit (local SQLite).

Made-with: Cursor